### PR TITLE
IP address ring based restrictions on internal routes 

### DIFF
--- a/configuration/base_stencil.yml
+++ b/configuration/base_stencil.yml
@@ -8,7 +8,7 @@ branding:
     name:  # The name of the maintainers
     homePage:  # The URL to the home page of the maintainers
 i18n:
-  languageCode:  # The languge code of the portal, like en-gb
+  languageCode:  # The language code of the portal, like en-gb
   timeZone:  # The time zone of the portal, like Asia/Kolkata
 secrets:
   secretKey: '' # 'fifty random characters'
@@ -43,8 +43,10 @@ integrations:  # Various useful applications that can connect to Django
     dsn:  # Unique URL for establishing a connection
 ipAddressRings:
 # For as many rings as you anticipate, repeat
-- name:  # The name of the network ring
+- name: administrator # Network ring for django admin portal (mandatory)
+  patterns:
+  - '*' # 'the regex of the IP pattern'
+- name: # The name of the network ring
   patterns:
   # For as many IP patterns as each ring contains, repeat
   - '' # 'the regex of the IP pattern'
-      

--- a/omniport/omniport/middleware/routes_control.py
+++ b/omniport/omniport/middleware/routes_control.py
@@ -1,0 +1,45 @@
+import re
+
+from django.conf import settings
+from django.http import Http404
+
+
+class RoutesControl:
+    """
+    Handle routing of specialised internal features that are to be
+    restricted under certain IP rings
+    """
+
+    def __init__(self, get_response):
+        """
+        __init__ function exactly as the Django documentations says for
+        a custom middleware
+        """
+        self.get_response = get_response
+
+        default_restrictions = [
+            (settings.ADMIN_SITE_URL, 'administrator'),
+        ]
+
+        self.restrictions = default_restrictions
+
+    def __call__(self, request):
+        """
+        Perform the actual processing on the request before it goes to the view
+        and on the response returned by the view
+        :param request: the request being processed
+        :return: the processed response
+        """
+
+        source_address = request.source_ip_address
+
+        for site_path, ip_address_ring_name in self.restrictions:
+            ip_patterns = settings.IP_ADDRESS_RINGS.get(ip_address_ring_name)
+            base = site_path.strip('/')
+            if re.match(f'^/{base}/', request.path) and \
+                    not re.search('|'.join(ip_patterns), source_address):
+                raise Http404
+
+        response = self.get_response(request)
+
+        return response

--- a/omniport/omniport/settings/base/__init__.py
+++ b/omniport/omniport/settings/base/__init__.py
@@ -1,3 +1,4 @@
+from omniport.settings.base.admin import *
 from omniport.settings.base.applications import *
 from omniport.settings.base.authentication import *
 from omniport.settings.base.directories import *

--- a/omniport/omniport/settings/base/admin.py
+++ b/omniport/omniport/settings/base/admin.py
@@ -1,0 +1,9 @@
+"""
+This setting is related to the Django admin site, the complete administrative
+panel of the portal for maintenance of data in the database for all apps and
+services.
+
+This settings define the route path to the admin panel
+"""
+
+ADMIN_SITE_URL = 'omnipotence/'

--- a/omniport/omniport/settings/base/middleware.py
+++ b/omniport/omniport/settings/base/middleware.py
@@ -20,6 +20,7 @@ MIDDLEWARE = [
     'omniport.middleware.drf_auth.DrfAuth',
 
     'omniport.middleware.ip_address_rings.IpAddressRings',
+    'omniport.middleware.routes_control.RoutesControl',
     'omniport.middleware.person_roles.PersonRoles',
     'omniport.middleware.last_seen.LastSeen',
 ]

--- a/omniport/omniport/urls/http_urls.py
+++ b/omniport/omniport/urls/http_urls.py
@@ -1,10 +1,11 @@
 from django.urls import path, include
+from django.conf import settings
 
 from omniport.admin.site import omnipotence
 
 http_urlpatterns = [
     # Django admin URL dispatcher
-    path('omnipotence/', omnipotence.urls),
+    path(settings.ADMIN_SITE_URL, omnipotence.urls),
 
     # PyPI packages URL dispatcher
     path('tinymce/', include('tinymce.urls')),


### PR DESCRIPTION
Role based access is already implemented. But for sometimes for security reasons, to restrict certain routes to certain IP patterns, a middleware has to control the requests. 