### PR TITLE
Add react-semantic-toasts package to show toast messages on the frontend

### DIFF
--- a/omniport/omniport/static/react-semantic-toasts/react-semantic-alert.css
+++ b/omniport/omniport/static/react-semantic-toasts/react-semantic-alert.css
@@ -1,0 +1,70 @@
+.ui-alerts {
+    position: fixed;
+    z-index: 2060;
+    padding: 23px;
+}
+
+.ui-alerts.center {
+    top: 50%;
+    left: 50%;
+    margin-top: -100px;
+    margin-left: -222px;
+}
+
+.ui-alerts.top-right {
+    top: 20px;
+    right: 20px;
+}
+
+.ui-alerts.top-center {
+    top: 20px;
+    margin-left: -222px;
+    left: 50%;
+}
+
+.ui-alerts.top-left {
+    top: 20px;
+    left: 20px;
+}
+
+.ui-alerts.bottom-right {
+    bottom: 0;
+    right: 20px;
+}
+.ui-alerts.bottom-center {
+    bottom: 0;
+    margin-left: -222px;
+    left: 50%;
+}
+
+.ui-alerts.bottom-left {
+    bottom: 0;
+    left: 20px;
+}
+
+.ui-alerts.ui-alerts > .message > .content > .header {
+    padding-right: 13px;
+}
+
+@media (min-width: 320px) {
+    /* smartphones, portrait iPhone, portrait 480x320 phones (Android) */
+    .ui-alerts.top-center {
+        margin-left: -163px;
+    }
+}
+@media (min-width: 480px) {
+    /* smartphones, Android phones, landscape iPhone */
+}
+@media (min-width: 600px) {
+    /* portrait tablets, portrait iPad, e-readers (Nook/Kindle), landscape 800x480 phones
+ * (Android) */
+}
+@media (min-width: 801px) {
+    /* tablet, landscape iPad, lo-res laptops ands desktops */
+}
+@media (min-width: 1025px) {
+    /* big landscape tablets, laptops, and desktops */
+}
+@media (min-width: 1281px) {
+    /* hi-res laptops and desktops */
+}


### PR DESCRIPTION
We really need some good notification/toasts system at the frontend which looks like `Message` component of the semantic-ui. This functionality is not provided by the semantic-ui for now. So, we can use this package (https://www.npmjs.com/package/react-semantic-toasts).