### PR TITLE
Enhace the admin side for some models from kernel

### DIFF
--- a/omniport/core/kernel/admin/model_admins/__init__.py
+++ b/omniport/core/kernel/admin/model_admins/__init__.py
@@ -1,1 +1,4 @@
+from kernel.admin.model_admins.faculty_member import FacultyMemberAdmin
+from kernel.admin.model_admins.branch import BranchAdmin
 from kernel.admin.model_admins.person import PersonAdmin
+from kernel.admin.model_admins.student import StudentAdmin

--- a/omniport/core/kernel/admin/model_admins/branch.py
+++ b/omniport/core/kernel/admin/model_admins/branch.py
@@ -1,0 +1,18 @@
+import swapper
+from django.contrib import admin
+
+from formula_one.admin.model_admins.base import ModelAdmin
+from omniport.admin.site import omnipotence
+
+Branch = swapper.load_model('kernel', 'Branch')
+
+
+@admin.register(Branch, site=omnipotence)
+class BranchAdmin(ModelAdmin):
+    """
+    This class controls the behaviour of Branch in Omnipotence
+    """
+
+    search_fields = [
+        'name'
+    ]

--- a/omniport/core/kernel/admin/model_admins/faculty_member.py
+++ b/omniport/core/kernel/admin/model_admins/faculty_member.py
@@ -1,0 +1,19 @@
+import swapper
+from django.contrib import admin
+
+from formula_one.admin.model_admins.base import ModelAdmin
+from omniport.admin.site import omnipotence
+
+FacultyMember = swapper.load_model('kernel', 'FacultyMember')
+
+
+@admin.register(FacultyMember, site=omnipotence)
+class FacultyMemberAdmin(ModelAdmin):
+    """
+    This class controls the behaviour of FacultyMember in Omnipotence
+    """
+
+    search_fields = [
+        'employee_id',
+        'person__full_name'
+    ]

--- a/omniport/core/kernel/admin/model_admins/student.py
+++ b/omniport/core/kernel/admin/model_admins/student.py
@@ -1,0 +1,19 @@
+import swapper
+from django.contrib import admin
+
+from formula_one.admin.model_admins.base import ModelAdmin
+from omniport.admin.site import omnipotence
+
+Student = swapper.load_model('kernel', 'Student')
+
+
+@admin.register(Student, site=omnipotence)
+class StudentAdmin(ModelAdmin):
+    """
+    This class controls the behaviour of Student in Omnipotence
+    """
+
+    search_fields = [
+        'enrolment_number',
+        'person__full_name'
+    ]


### PR DESCRIPTION
Added Search with pagination in 3 models from the kernel, but I think it should be added to the other models attached to Person model like BiologicalInformatoin, Financial etc. These things make the management of the portal easy. I can't figure out how to enhance the admin view for other models like in formula_one where the models are essentially identified by the GenericForeignKey.