### PR TITLE
Add empty object in front of integrations in the base_stencil file

### DIFF
--- a/configuration/base_stencil.yml
+++ b/configuration/base_stencil.yml
@@ -37,10 +37,9 @@ services:
     port:  # 5672, or your own server configuration
     user:  # Same as message_broker.env, or your own server configuration
     password:  # Same as message_broker.env, or your own server configuration
-integrations:  # Various useful applications that can connect to Django
+integrations: {}
+  # Various useful applications that can connect to Django
   # Freely drop any integration you do not use or need
-  sentry: # Error tracking software
-    dsn:  # Unique URL for establishing a connection
 ipAddressRings:
 # For as many rings as you anticipate, repeat
 - name: administrator # Network ring for django admin portal (mandatory)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34851451/71419786-68e55a80-2697-11ea-88ff-df26ab23ce01.png)
In case of an empty object, yaml doesn't take it as an iterable type and gives the error.