### PR TITLE
Bug Fix: Enable INFO level logging

### DIFF
--- a/omniport/core/discovery/discovery.py
+++ b/omniport/core/discovery/discovery.py
@@ -292,6 +292,7 @@ class Discovery:
         for (_, app_configuration) in app_set:
             app = app_configuration.nomenclature.name
             loggers[app] = {
+                'level': 'INFO',
                 'handlers': [
                     'console',
                     app,

--- a/omniport/omniport/settings/configuration/logging.py
+++ b/omniport/omniport/settings/configuration/logging.py
@@ -65,6 +65,7 @@ LOGGING = {
     # Loggers
     'loggers': {
         'django': {
+            'level': 'INFO',
             'handlers': [
                 'console',
                 'file',


### PR DESCRIPTION
In the current logging architecture, WARN level logging was enabled by default in Django loggers, whereas the intention was to enable INFO level logging. With reference to [this](https://stackoverflow.com/questions/30451387/django-logging-only-logs-warning-and-error) thread on StackOverflow, the bug has been fixed.