### PR TITLE
Fix OAuth migration issues

### DIFF
--- a/omniport/core/open_auth/migrations/0001_initial.py
+++ b/omniport/core/open_auth/migrations/0001_initial.py
@@ -19,6 +19,10 @@ class Migration(migrations.Migration):
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 
+    run_before = [
+        ('oauth2_provider', '0001_initial'),
+    ]
+
     operations = [
         migrations.CreateModel(
             name='Application',


### PR DESCRIPTION
Currently, a few issues arise due to the migration orders of OAuth(`open_auth` and `oauth2_provider`). The details of these issues can be found at https://github.com/jazzband/django-oauth-toolkit/issues/319.  Another problem is that when initally running migrations, the migrations for `oauth2_provider` runs before `open_auth` and thus it throws an error since the new Application Model isn't created. This PR fixes that.