### PR TITLE
Add default value to user_agent_string in session_map creation

### DIFF
--- a/omniport/core/session_auth/models/session_map.py
+++ b/omniport/core/session_auth/models/session_map.py
@@ -76,7 +76,7 @@ class SessionMap(Model):
         session_map.location = location
 
         # Get the browser, operating system and device from the user-agent
-        user_agent_string = request.META['HTTP_USER_AGENT']
+        user_agent_string = request.META.get('HTTP_USER_AGENT','Unknown')
         (browser, os, device_type) = get_agent_information(user_agent_string)
         session_map.user_agent = user_agent_string
         session_map.browser_family = browser.family

--- a/omniport/core/session_auth/models/session_map.py
+++ b/omniport/core/session_auth/models/session_map.py
@@ -76,7 +76,7 @@ class SessionMap(Model):
         session_map.location = location
 
         # Get the browser, operating system and device from the user-agent
-        user_agent_string = request.META.get('HTTP_USER_AGENT','Unknown')
+        user_agent_string = request.META.get('HTTP_USER_AGENT', 'Unknown')
         (browser, os, device_type) = get_agent_information(user_agent_string)
         session_map.user_agent = user_agent_string
         session_map.browser_family = browser.family


### PR DESCRIPTION
Me and @shaddygarg were working on a project application and observed this. :sweat_smile:  If the user-agent string is NULL, the backend throws a 500 right now. This fixes that