### PR TITLE
Move celery start script to kernel

### DIFF
--- a/omniport/core/kernel/management/commands/collectdaemon.py
+++ b/omniport/core/kernel/management/commands/collectdaemon.py
@@ -41,20 +41,27 @@ class Command(BaseCommand):
                 try:
                     os.symlink(
                         file,
-                        os.path.join(destination_root, os.path.basename(file))
+                        os.path.join(destination_root, f'{app.name}_{os.path.basename(file)}') # Namespace the scripts by the app name
                     )
-                except OSError:
+                    successful_apps.add(app.name)
+                except OSError as exception:
                     self.stdout.write(
                         self.style.WARNING(
                             f'Failed to fetch file {os.path.basename(file)} '
-                            f'for app {app.name}'
+                            f'for app {app.name}\n'
+                            f'Error: {str(exception)}'
                         )
                     )
-                successful_apps.add(app.name)
-
-        self.stdout.write(
-            self.style.SUCCESS(
-                f'Successfully collected daemon scripts for '
-                f'{", ".join(successful_apps)}'
+        if len(successful_apps):        
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'Successfully collected daemon scripts for '
+                    f'{", ".join(successful_apps)}'
+                )
             )
-        )
+        else:
+            self.stdout.write(
+                self.style.WARNING(
+                    'No daemon scripts collected'
+                )
+            )

--- a/omniport/core/kernel/supervisor.d/celery.conf
+++ b/omniport/core/kernel/supervisor.d/celery.conf
@@ -1,0 +1,10 @@
+[program:celery]
+command=celery -A omniport worker -l info
+
+stdout_logfile=/web_server_logs/supervisord_logs/celery-%(ENV_SITE_ID)s-stdout.log
+stdout_logfile_maxbytes=1048576
+stdout_logfile_backups=32
+
+stderr_logfile=/web_server_logs/supervisord_logs/celery-%(ENV_SITE_ID)s-stderr.log
+stderr_logfile_maxbytes=1048576
+stderr_logfile_backups=32


### PR DESCRIPTION
- Move the celery start script to kernel from notifications, since it is common for all apps and services.
- Add namespace to supervisord file name according to app name, to avoid naming conflicts