### PR TITLE
Shorten JWT lifetimes, add scoped throttling, and validate proxy IP headers

### DIFF
--- a/omniport/core/base_auth/views/recover_passowrd.py
+++ b/omniport/core/base_auth/views/recover_passowrd.py
@@ -1,6 +1,7 @@
 import swapper
 from django.core.cache import cache
 from rest_framework import generics, response, status
+from rest_framework.throttling import ScopedRateThrottle
 
 from base_auth.constants.password_recovery import (
     ACCOUNT_RATE_LIMIT,
@@ -158,6 +159,9 @@ class RecoverPassword(generics.GenericAPIView):
 
 
 class VerifyRecoveryToken(generics.GenericAPIView):
+
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'verify_recovery_token'
 
     @verify_access_token
     def get(self, request, *args):

--- a/omniport/core/base_auth/views/verify_secret_answer.py
+++ b/omniport/core/base_auth/views/verify_secret_answer.py
@@ -1,4 +1,5 @@
 from rest_framework import status, generics, response
+from rest_framework.throttling import ScopedRateThrottle
 
 from base_auth.serializers.retrieve_user import (
     RetrieveUserSerializer,
@@ -15,6 +16,8 @@ class VerifySecretAnswer(generics.GenericAPIView):
     username, the secret_answer and the new password to reset it
     """
 
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'verify_secret_answer'
     serializer_class = VerifySecretAnswerSerializer
 
     def get(self, request, *args, **kwargs):

--- a/omniport/core/session_auth/utils/ip_address.py
+++ b/omniport/core/session_auth/utils/ip_address.py
@@ -1,3 +1,5 @@
+import ipaddress
+
 import requests
 
 from core.utils.logs import get_logging_function
@@ -12,8 +14,13 @@ def get_location(ip_address):
     :param ip_address: the IP address to geo-locate
     :return: the approximate location of the IP address
     """
-    try:
 
+    try:
+        ipaddress.ip_address(ip_address)
+    except ValueError:
+        return 'The Void'
+
+    try:
         fields = ','.join([
             'status',
             'message',

--- a/omniport/core/session_auth/views/logout.py
+++ b/omniport/core/session_auth/views/logout.py
@@ -17,9 +17,9 @@ class Logout(generics.GenericAPIView):
 
     permission_classes = [permissions.IsAuthenticated, ]
 
-    def get(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         """
-        View to serve GET requests
+        View to serve POST requests
         :param request: the request that is to be responded to
         :param args: arguments
         :param kwargs: keyword arguments
@@ -42,3 +42,7 @@ class Logout(generics.GenericAPIView):
             data=response_data,
             status=status.HTTP_200_OK
         )
+
+    def get(self, request, *args, **kwargs):
+        """Deprecated: use POST. Kept for backward compatibility."""
+        return self.post(request, *args, **kwargs)

--- a/omniport/core/token_auth/views.py
+++ b/omniport/core/token_auth/views.py
@@ -4,6 +4,8 @@ Django REST framework, we override the views to explicitly use the parsers and
 renderers as they were before JSON API came along.
 """
 
+from django.conf import settings
+
 from rest_framework.parsers import (
     JSONParser,
     FormParser,
@@ -20,7 +22,9 @@ from rest_framework_simplejwt.views import (
 )
 
 PARSERS_MINUS_JSON_API = (JSONParser, FormParser, MultiPartParser,)
-RENDERERS_MINUS_JSON_API = (JSONRenderer, BrowsableAPIRenderer,)
+RENDERERS_MINUS_JSON_API = (
+    (JSONRenderer, BrowsableAPIRenderer,) if settings.DEBUG else (JSONRenderer,)
+)
 
 
 class ObtainPair(TokenObtainPairView):

--- a/omniport/omniport/middleware/ip_address_rings.py
+++ b/omniport/omniport/middleware/ip_address_rings.py
@@ -1,3 +1,4 @@
+import ipaddress
 import re
 
 from django.conf import settings
@@ -25,23 +26,20 @@ class IpAddressRings:
         :return: the processed response
         """
 
-        # The headers to read in order of preference
-        real_ip_header = 'HTTP_X_REAL_IP'
-        forwarded_for_header = 'HTTP_X_FORWARDED_FOR'
-        remote_addr = 'REMOTE_ADDR'
-
-        # The IP address is extracted from the right header
-        # The right header depends on whether the request was proxied by NGINX
-        ip_address = request.META.get(
-            real_ip_header,
+        # Extract IP from proxy headers (set by NGINX) or direct connection.
+        # X-Forwarded-For may be a comma-separated list; take the first entry.
+        raw_ip = request.META.get(
+            'HTTP_X_REAL_IP',
             request.META.get(
-                forwarded_for_header,
-                request.META.get(
-                    remote_addr,
-                    'Not Found'
-                )
+                'HTTP_X_FORWARDED_FOR',
+                request.META.get('REMOTE_ADDR', 'Not Found')
             )
         )
+        ip_address = raw_ip.split(',')[0].strip()
+        try:
+            ipaddress.ip_address(ip_address)
+        except ValueError:
+            ip_address = request.META.get('REMOTE_ADDR', 'Not Found')
         request.source_ip_address = ip_address
 
         ip_address_rings = settings.IP_ADDRESS_RINGS

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -26,4 +26,12 @@ REST_FRAMEWORK = {
         'rest_framework.pagination.PageNumberPagination'  # No commas
     ),
     'PAGE_SIZE': 10,
+    # ScopedRateThrottle only applies to views that declare a throttle_scope
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.ScopedRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'verify_secret_answer': '5/hour',
+        'verify_recovery_token': '10/hour',
+    },
 }

--- a/omniport/omniport/settings/third_party/jwt.py
+++ b/omniport/omniport/settings/third_party/jwt.py
@@ -5,6 +5,6 @@ This settings file exposes settings for Simple JWT
 import datetime as _datetime
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': _datetime.timedelta(days=1),
+    'ACCESS_TOKEN_LIFETIME': _datetime.timedelta(minutes=15),
     'REFRESH_TOKEN_LIFETIME': _datetime.timedelta(weeks=26),
 }


### PR DESCRIPTION
### Summary

Rebased onto master now that the OAuth `eval()` removal and the password recovery hardening have landed. What remains is the part of this branch that nothing else covers.

**JWT access token lifetime** drops from one day to fifteen minutes (`settings/third_party/jwt.py`). The refresh token lifetime is unchanged.

**Scoped throttling** on the two account recovery views that had none (`settings/third_party/drf.py`, `verify_secret_answer.py`, `recover_passowrd.py`). `ScopedRateThrottle` is registered as a default class, which only affects views declaring a `throttle_scope`, so nothing else in the project changes behaviour. `VerifySecretAnswer` is limited to 5 per hour and `VerifyRecoveryToken` to 10 per hour.

**Proxy header validation** (`middleware/ip_address_rings.py`). `X-Forwarded-For` may carry a comma-separated list, and the previous code used the whole string as the client address, so a request that arrived through more than one hop produced a value matching no ring. The first entry is now taken and validated as an IP address, falling back to `REMOTE_ADDR` when it is not one. `get_location` gains the same validation, so a non-address is not sent to the geolocation API.

**Logout accepts POST** (`session_auth/views/logout.py`), with GET kept as a deprecated alias so existing clients keep working.

**The browsable API renderer is limited to DEBUG** (`token_auth/views.py`), so the token endpoints do not serve an HTML form in production.

### What was dropped in the rebase, and why

The `eval()` removal in `open_auth`, the `re.fullmatch` anchoring in `AppAccessTokenAuthentication`, the `request.auth` lookup in `GetUserData` and the bounded alohomora split all landed in master separately. Those files are no longer part of this branch.

The security settings hunk is dropped, since master now sets the response headers in `settings/base/security.py` and the transport settings inside the non-DEBUG branch of `settings.py`. Two items from it are deliberately not carried over:

- `CSRF_COOKIE_HTTPONLY = True`. The frontends read the token with `getCookie('csrftoken')` in JavaScript, across a number of call sites in the frontend repositories. Making the cookie HttpOnly means `document.cookie` cannot see it, `X-CSRFToken` is sent empty, and every POST, PUT, PATCH and DELETE in the portal fails CSRF validation.
- `X_FRAME_OPTIONS = 'DENY'`. Master already sets `SAMEORIGIN`.

The `guest_auth` logout change is dropped along with that app.

The ip-api URL stays on `http`. The free tier answers `https` with a 403 whose body is valid JSON, so the switch would have parsed without error and recorded every session location as `The Void`, permanently and silently. The `ipaddress` validation from the same change is kept.

`ROTATE_REFRESH_TOKENS` is dropped. Without the `token_blacklist` app and `BLACKLIST_AFTER_ROTATION`, rotation issues a new refresh token without invalidating the old one, which only widens the set of valid tokens. Worth adding properly in its own change.

The `recover_password` throttle scope is dropped because master already limits that view per IP and per account. The two remaining scopes do not overlap with it.

Two corrections while rebasing: in `verify_secret_answer.py` the throttle attributes sat above the class docstring, which turned the docstring into a bare string statement, and they now sit below it; in `token_auth/views.py` the `settings` import moves to the top of the file.

### What this PR does not claim

The original description mentioned a CSRF fix on logout. Adding `post()` while keeping a `get()` alias does not achieve that, because a caller can still use GET. Removing the alias is a breaking change for any client still calling it, so it is left for a follow-up once those clients are known. The change here is preparatory.

### Test plan

No test suite exists in this repository, so the following are manual.

- Log in and confirm the session still works after fifteen minutes, exercising whatever refresh path the client uses. This is the change most likely to surface a client that never implemented refresh, and is the main thing to watch on staging.
- A sixth `VerifySecretAnswer` request within the hour returns 429, and the fifth still succeeds.
- An eleventh `VerifyRecoveryToken` request within the hour returns 429.
- Endpoints without a `throttle_scope` are unaffected by the new default throttle class.
- A request arriving with `X-Forwarded-For: <client>, <proxy>` resolves to the client address and lands in the expected ring, where previously the whole string matched none.
- A request with a malformed `X-Real-IP` falls back to `REMOTE_ADDR` rather than propagating the bad value.
- Session records created at login still show a real location rather than `The Void`.
- `POST` to the logout endpoint ends the session, and `GET` still does too.
- With `DEBUG = False`, the token endpoints return JSON rather than the browsable HTML form.