### PR TITLE
Register a serializer for the NonTeachingStaff role

### DIFF
--- a/omniport/core/kernel/serializers/registration.py
+++ b/omniport/core/kernel/serializers/registration.py
@@ -39,6 +39,10 @@ KERNEL_JOINTFACULTY_SERIALIZER = (
     'kernel.serializers.roles.'
     'joint_faculty.JointFacultySerializer'
 )
+KERNEL_NONTEACHINGSTAFF_SERIALIZER = (
+    'kernel.serializers.roles.'
+    'nonteaching_staff.NonTeachingStaffSerializer'
+)
 
 KERNEL_BIOLOGICALINFORMATION_SERIALIZER = (
     'kernel.serializers.personal_information.'
@@ -79,6 +83,7 @@ __all__ = [
     'KERNEL_GUEST_SERIALIZER',
     'KERNEL_JOINTFACULTYMEMBERSHIP_SERIALIZER',
     'KERNEL_JOINTFACULTY_SERIALIZER',
+    'KERNEL_NONTEACHINGSTAFF_SERIALIZER',
 
 
     'KERNEL_BIOLOGICALINFORMATION_SERIALIZER',

--- a/omniport/core/kernel/serializers/roles/nonteaching_staff.py
+++ b/omniport/core/kernel/serializers/roles/nonteaching_staff.py
@@ -1,0 +1,20 @@
+import swapper
+
+from kernel.serializers.roles.base import RoleSerializer
+
+class NonTeachingStaffSerializer(RoleSerializer):
+    """
+    Serializer for NonTeachingStaff Object
+    """
+
+    class Meta:
+        """
+        Meta class for non-teaching staff
+        """
+
+        model = swapper.load_model('kernel', 'NonTeachingStaff')
+
+        fields = [
+            'id',
+            'person',
+        ]


### PR DESCRIPTION
## Summary

`NonTeachingStaff` is registered in `settings.ROLES` (`kernel/models/roles/__init__.py`) but no `KERNEL_NONTEACHINGSTAFF_SERIALIZER` was ever added to `kernel/serializers/registration.py`.

`switcher.load_serializer` returns `None` rather than raising when a serializer setting is absent, so `process_roles` reached `None(role_instance, excluded_fields=['person'])` and raised `TypeError: 'NoneType' object is not callable` for every person holding the role. Because `AvatarSerializer` is what fails, this took down `session_auth` login (including alohomora, which shares the view), `guest_auth` login, `who_am_i`, and the `base_auth` recovery-token step, i.e. non-teaching staff could neither log in nor reset their password.

This adds `NonTeachingStaffSerializer`, modelled on `GuestSerializer`. The role model extends `AbstractRole` without adding fields, and the `shell` implementation adds none either, so `['id', 'person']` covers it and no shell-side registration override is needed.

## Test plan

- On a database with a person holding the `NonTeachingStaff` role, `AvatarSerializer(person).data` raised `TypeError` before this change and returns the serialized avatar with a populated `roles` list after it.
- `POST /session_auth/login/` for that person returned 500 before and returns 200 after.
- Password recovery for that person completes through the `base_auth` verify step.
- Logins for persons holding other roles (student, faculty member, maintainer) are unaffected, since `get_all_roles` only builds entries for roles a person actually holds.