### PR TITLE
Make the guest route guard match the routes it guards

### DIFF
--- a/omniport/omniport/middleware/routes_control_roles.py
+++ b/omniport/omniport/middleware/routes_control_roles.py
@@ -43,10 +43,17 @@ class RoutesControlRoles:
             raise Http404
 
         DISCOVERY = settings.DISCOVERY
-        all_apps = DISCOVERY.apps
+        all_apps = DISCOVERY.services + DISCOVERY.apps
 
         for app, app_configuration in all_apps:
-            base_url = app_configuration.base_urls.http.strip('/')
+            base_url = app_configuration.base_urls.http
+            if base_url is None:
+                continue
+            base_url = base_url.strip('/')
+            # The URL dispatcher mounts API apps under api/, so the guard has
+            # to match the same prefix or it never fires
+            if app_configuration.is_api:
+                base_url = f'api/{base_url}'
             if (
                 app_configuration.guest_allowed
                 or from_acceptable_person(


### PR DESCRIPTION
### Summary

`RoutesControlRoles` exists to confine the guest user to apps that either set `guestAllowed` or accept one of the guest's roles. It has never done that, for two independent reasons, so the only guest restriction actually in force today is the `request.method != 'GET'` check above it.

1. It iterated `DISCOVERY.apps` only. `Discovery.discover()` populates `services` and `apps` as separate lists, so every service was skipped entirely and was never guarded for guests at all.
2. It matched `^/{base_url}/`, but `Discovery._prepare_http_urlpatterns` mounts an app with `isApi` set under `api/{base_url}`. The pattern could not match a real API path. The sibling `RoutesControl` middleware builds the same prefix correctly, which is what makes the omission visible.

`base_url` is checked for `None` because a config may omit `baseUrls.http`; `Discovery` already skips those when building urlpatterns, and without the guard `.strip()` would raise on the first guest request once services enter the loop.

### Blast radius

This activates guards that have been inert since they were written, so it is worth being explicit about who is newly affected.

The middleware returns early for any user other than the guest (`source_user != guest_user`), so no authenticated user's routing changes. For guests, an app is only newly blocked if it declares a non-empty `acceptables.roles` and does not set `guestAllowed`, because `from_acceptable_person` treats an empty or absent role list as allow.

Across the apps and services checked out locally, that is one app: `r-pravesh`, which declares `r_pravesh.SecurityAdmin` and is `isApi: true`. Guests will now get a 404 on `/api/r_pravesh/*`, which is what its `config.yml` has been asking for. `noticeboard` declares only `ipAddressRings` under `acceptables` and stays guest-visible; `bhawan-app` declares no `acceptables` and is likewise unaffected.

Anyone deploying this should confirm no production app was relying on the broken behaviour to stay guest-visible. The fix for such an app is to set `guestAllowed: true` or leave `acceptables.roles` empty, both of which are already supported.

### Test plan

- `omniport/omniport/middleware/routes_control_roles.py` compiles clean.
- Attribute names verified against source rather than assumed: `is_api` and `guest_allowed` at `core/configuration/models/app/app.py:28,40`; `services` and `apps` populated separately at `core/discovery/discovery.py:110-122`; the `api/` prefix applied at `core/discovery/discovery.py:230-231`.
- With a guest session, a GET to an app that declares acceptable roles it does not hold should go from 200 to 404. `GET /api/r_pravesh/` is the case available here.
- With a guest session, a GET to an app declaring no acceptable roles should still return 200.
- With a normal authenticated session, routing is unchanged on both.

The backend has no test suite, so no test file is added rather than introducing one for a single change.