### PR TITLE
Replace eval() in OAuth data retrieval and anchor the IP allow-list

### DIFF
--- a/omniport/core/base_auth/backends/generalised.py
+++ b/omniport/core/base_auth/backends/generalised.py
@@ -25,7 +25,7 @@ class GeneralisedAuthBackend(ModelBackend):
 
         if '_alohomora_' in username:
             alohomora_login = True
-            (account_holder, account_accessor) = username.split('_alohomora_')
+            (account_holder, account_accessor) = username.split('_alohomora_', 1)
         else:
             alohomora_login = False
             (account_holder, account_accessor) = (username, username)

--- a/omniport/core/open_auth/utils.py
+++ b/omniport/core/open_auth/utils.py
@@ -10,21 +10,42 @@ from categories.models import Category
 AvatarSerializer = switcher.load_serializer('kernel', 'Person', 'Avatar')
 
 
+def _resolve(obj, path):
+    """
+    Walk a dotted attribute path, calling a segment that ends in '()'
+    :param obj: the object to start the walk from
+    :param path: the dotted path, whose segments may end in '()'
+    :return: the resolved value, or None if any segment is absent
+    """
+
+    for part in path.split('.'):
+        if obj is None:
+            return None
+        if part.endswith('()'):
+            method = getattr(obj, part[:-2], None)
+            obj = method() if callable(method) else None
+        else:
+            obj = getattr(obj, part, None)
+    return obj
+
+
 def get_field_data(person, field_data_points, object_string):
     """
     Utility function to get requested model's data
     :param person: person object whose data is to be retrieved
     :param field_data_points: the specific fields of a model to be retrieved
-    :param object_string: object variable name to access the data
+    :param object_string: dotted path to the model, rooted at the person
     :return: data for a model string
     """
 
     data = dict()
-    if eval(object_string) is None:
+    # The first segment of object_string names the person itself
+    _, _, path = object_string.partition('.')
+    obj = _resolve(person, path) if path else person
+    if obj is None:
         return data
     for field_data_point in field_data_points:
-        data[f'{field_data_point.replace(".", " ")}'] = \
-            eval(f'{object_string}.{field_data_point}')
+        data[field_data_point.replace('.', ' ')] = _resolve(obj, field_data_point)
     return data
 
 

--- a/omniport/core/open_auth/views/retrieve_data.py
+++ b/omniport/core/open_auth/views/retrieve_data.py
@@ -3,7 +3,6 @@ from rest_framework import status, generics
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
-from oauth2_provider.models import AccessToken
 
 from kernel.models import Person
 from open_auth.utils import (
@@ -46,9 +45,7 @@ class GetUserData(generics.GenericAPIView):
         :return: the response for request
         """
 
-        token = request.headers['Authorization'].replace('Bearer ', '')
-
-        access_token = AccessToken.objects.get(token=token)
+        access_token = request.auth
         application = access_token.application
 
         if application is None:

--- a/omniport/core/token_auth/authentication/app_access_token_authentication.py
+++ b/omniport/core/token_auth/authentication/app_access_token_authentication.py
@@ -17,7 +17,7 @@ class AppAccessTokenAuthentication(authentication.BaseAuthentication):
                     access_token=access_token
                 )
                 allowed_ip_address_regex = app_access_token.ip_address_regex
-                if re.search(allowed_ip_address_regex, ip_address):
+                if re.fullmatch(allowed_ip_address_regex, ip_address):
                     return (app_access_token, None)
                 else:
                     raise exceptions.AuthenticationFailed('Request not allowed from' \


### PR DESCRIPTION
### Summary

Split out of #214 so the two remotely-reachable issues can land without waiting on the settings changes in that PR.

**`eval()` in OAuth data retrieval.** `get_field_data` evaluated two strings as Python: the model path, and each requested field interpolated onto it. Both derive from an OAuth application's `data_points`, which is a database-backed field, so any write to that row gave code execution as the application server user. This replaces both with a dotted-path walk over `getattr`, which covers every value the column can legitimately hold and cannot execute anything.

**Unanchored IP allow-list.** `AppAccessTokenAuthentication` matched the stored `ip_address_regex` with `re.search`, which is unanchored. A token restricted to `10.0.0.1` therefore also authenticated a request from `110.0.0.15`. `re.fullmatch` anchors it.

Two smaller changes come along because they sit in the same call paths:

`GetUserData` re-read the bearer token out of the `Authorization` header and looked it up again with `AccessToken.objects.get`, a second lookup path that repeated work `OAuth2Authentication` had already done and validated. It now uses `request.auth`, which that authentication class populates with the same `AccessToken` instance. The now-unused import is removed.

The alohomora username split is bounded to one, so an account accessor containing the separator no longer raises on tuple unpacking.

### Behaviour

Preserved for every legitimate input. The six `MODEL_STRINGS` values are `person`, `person.student`, `person.facultymember`, `person.biologicalinformation`, `person.contact_information.first()` and `person.residentialinformation`; the resolver handles the plain attribute segments and the trailing `first()` call. Absent roles behave as before: a missing reverse one-to-one raises `RelatedObjectDoesNotExist`, which subclasses `AttributeError`, so `getattr` with a default returns `None` and the caller still receives an empty dict.

One difference worth noting. Previously a field name that did not resolve raised `AttributeError`, which the caller caught and turned into an empty dict for the whole model. Now that field is `None` and the model's other fields are still returned. That only affects `data_points` rows naming a field that does not exist.

### Reviewer note on the resolver

The first segment of `object_string` names the person itself rather than an attribute of it, because in the original `eval` it referred to the local variable. A traversal that walks every segment starting from `person` resolves `getattr(person, 'person')`, which is `None`, and returns an empty dict for all six models. The first segment is therefore partitioned off before the walk. Worth checking explicitly in review, since it is silent when wrong: OAuth consumers receive empty payloads rather than an error.

### Test plan

The backend has no test suite, so the resolver was verified out of band against the six real `MODEL_STRINGS` and a stub object graph:

| Case | Expected | Result |
| --- | --- | --- |
| `person` + `full_name` | value returned | pass |
| `person.student` + `enrolment_number` | value returned | pass |
| `person.student` + `branch.name` (nested field path) | value returned, key `branch name` | pass |
| `person.contact_information.first()` + `email_address` | value returned | pass |
| `person.facultymember` on a person with no faculty role | empty dict | pass |
| `person.biologicalinformation` when absent | empty dict | pass |
| a field name containing an expression | resolves to `None`, nothing executes | pass |

`grep -rn "eval(" omniport/core/open_auth/` returns nothing. All four files compile clean.

Before deploying, audit the stored `AppAccessToken.ip_address_regex` values. Any written as an anchored prefix, such as `^10\.0\.`, matched under `re.search` and will stop matching under `re.fullmatch`.