### PR TITLE
Add the media authorisation endpoint and the object owner permission

### DIFF
--- a/omniport/core/kernel/permissions/is_object_owner.py
+++ b/omniport/core/kernel/permissions/is_object_owner.py
@@ -1,0 +1,58 @@
+from rest_framework.permissions import BasePermission
+
+
+def _resolve(obj, dotted_path):
+    """
+    Safely walk a dotted attribute path from ``obj`` using getattr, returning
+    None if any segment along the way is missing or None.
+    :param obj: the object to start traversal from
+    :param dotted_path: the dotted attribute path to resolve
+    :return: the resolved value, or None if it cannot be resolved
+    """
+
+    current = obj
+    for segment in dotted_path.split('.'):
+        if current is None:
+            return None
+        current = getattr(current, segment, None)
+    return current
+
+
+class IsObjectOwner(BasePermission):
+    """
+    Object-level permission that grants access only when the requesting person
+    owns the object.
+
+    Ownership is resolved by comparing ``request.person`` against the first
+    matching attribute in a list of candidate dotted paths on the object. A view
+    may override the candidates by setting ``object_owner_fields`` on itself,
+    e.g. ``object_owner_fields = ('student.person',)``.
+
+    This closes broken-object-level-authorization (BOLA / CWE-639) on detail
+    actions (retrieve/update/destroy), which invoke ``has_object_permission``
+    via ``get_object()``. It must be combined with ``IsAuthenticated`` so that
+    list/create actions - which do not call ``has_object_permission`` - remain
+    gated too.
+    """
+
+    default_owner_fields = (
+        'person',
+        'student.person',
+        'faculty_member.person',
+        'user.person',
+        'owner',
+    )
+
+    def has_object_permission(self, request, view, obj):
+        request_person = getattr(request, 'person', None)
+        if request_person is None:
+            return False
+
+        owner_fields = getattr(
+            view, 'object_owner_fields', self.default_owner_fields
+        )
+        for field in owner_fields:
+            owner = _resolve(obj, field)
+            if owner is not None and owner == request_person:
+                return True
+        return False

--- a/omniport/core/session_auth/http_urls.py
+++ b/omniport/core/session_auth/http_urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from session_auth.views.login import Login
 from session_auth.views.logout import Logout
 from session_auth.views.illustration_roulette import IllustrationRoulette
+from session_auth.views.media_authorisation import MediaAuthorisation
 
 app_name = 'session_auth'
 
@@ -13,5 +14,10 @@ urlpatterns = [
         'illustration_roulette/',
         IllustrationRoulette.as_view(),
         name='illustration_roulette'
-    )
+    ),
+    path(
+        'media_authorisation/',
+        MediaAuthorisation.as_view(),
+        name='media_authorisation'
+    ),
 ]

--- a/omniport/core/session_auth/views/media_authorisation.py
+++ b/omniport/core/session_auth/views/media_authorisation.py
@@ -1,0 +1,30 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.status import HTTP_200_OK
+from rest_framework.views import APIView
+
+
+class MediaAuthorisation(APIView):
+    """
+    Authorisation endpoint for nginx ``auth_request``. It gates protected static
+    files (media, personal files) that nginx would otherwise serve directly with
+    no access control, exposing institute PII to unauthenticated callers.
+
+    nginx issues an internal sub-request here before serving a protected file
+    and serves the file only on a 2xx response. Authenticated callers receive
+    200; unauthenticated callers are rejected by the IsAuthenticated permission,
+    so nginx denies the file.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        """
+        View to serve GET requests
+        :param request: the request that is to be responded to
+        :param args: arguments
+        :param kwargs: keyword arguments
+        :return: an empty 200 response for authenticated callers
+        """
+
+        return Response(status=HTTP_200_OK)


### PR DESCRIPTION
### Summary

Both pieces here were written by @lakshita10341 for #223 and are extracted unchanged. That PR was closed for reasons unrelated to these two files, which left two open pull requests depending on code that is not on `master`.

**`MediaAuthorisation`** (`session_auth/views/media_authorisation.py`, routed at `/session_auth/media_authorisation/`) answers the nginx `auth_request` sub-request that gates `/media` and `/personal`. nginx currently serves both straight off disk with `alias`, so Django never sees the request and profile pictures, lecture files, notice attachments and personal files are readable by anyone who knows or can guess a path.

**`IsObjectOwner`** (`kernel/permissions/is_object_owner.py`) is an object-level permission for detail actions, resolving ownership by walking a dotted path against `request.person`, with the candidate paths overridable per view via `object_owner_fields`.

Neither is wired into an existing view, so nothing changes in this repository until a consumer opts in.

### Why this needs to land first

IMGIITRoorkee/omniport-docker#57 adds `auth_request /_media_auth` and proxies it to `/session_auth/media_authorisation/`. `auth_request` denies the file on any non-2xx response, and a route that does not exist returns 404, so merging that change against the current `master` would fail every request for `/media` and `/personal` across the portal. The route has to exist before the nginx change ships.

IMGIITRoorkee/omniport-app-people-search#11 has `from kernel.permissions.is_object_owner import IsObjectOwner` at module scope. Without this file it raises `ImportError` at import time, which takes down every people-search endpoint rather than failing on one view.

### Limitations worth stating plainly

`MediaAuthorisation` proves that the caller has a session, not that they may read the particular file. nginx passes the requested path as `X-Original-URI` and the view does not consult it. For `/media` that matches the intent, since the goal is to stop anonymous internet access to institute media. For `/personal`, which is per-user, it means any authenticated user can still read another user's files by path. Closing that needs per-object checks against the file store, which is a larger change and belongs in its own PR alongside the `django_filemanager` ownership model.

`IsObjectOwner` only affects detail actions. DRF does not call `has_object_permission` for `list` or `create`, so it must be paired with `IsAuthenticated`, as its docstring says and as people-search#11 does. It is not a substitute for gating collection endpoints.

### Test plan

- `GET /session_auth/media_authorisation/` with a valid session cookie returns 200 with an empty body.
- The same request with no session returns 401 or 403, which is what makes nginx deny the file.
- The route resolves at exactly `/session_auth/media_authorisation/`, matching the upstream proxied by omniport-docker#57; `session_auth` is mounted at `session_auth/` in `omniport/urls/http_urls.py`.
- No existing endpoint changes behaviour, since neither class is referenced by any view in this repository.

After this merges, omniport-docker#57 can be deployed to staging and verified end to end: a logged-in browser loads avatars and notice images as before, and a request for the same URL with no cookie is refused by nginx rather than served.