### PR TITLE
Deny by default on views that declare no permission

### DIFF
--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -26,6 +26,10 @@ REST_FRAMEWORK = {
         'rest_framework.pagination.PageNumberPagination'  # No commas
     ),
     'PAGE_SIZE': 10,
+    # A view that declares no permission_classes must not be public by default
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
     # ScopedRateThrottle only applies to views that declare a throttle_scope
     'DEFAULT_THROTTLE_CLASSES': [
         'rest_framework.throttling.ScopedRateThrottle',


### PR DESCRIPTION
## Summary

> **Merge last.**
> This is the final step of a coordinated change. Every allow-list PR listed under "Ordering" must be merged and deployed first, or this locks people out of the login page, password recovery, new-user registration and the gym turnstile.

Sets `DEFAULT_PERMISSION_CLASSES` to `IsAuthenticated`, so a view that declares no permissions stops being published to the internet by default.

DRF resolves a view's permissions as: the view's own `permission_classes`, else `DEFAULT_PERMISSION_CLASSES`, else its built-in fallback of `AllowAny`. This project has never set the middle one, so the fallback applied and any view that omitted the line was published to the internet.

## Issue

That single default accounts for most of the unauthenticated data exposure found across the platform. Nobody decided to make faculty search, the R Drive file listing, group memberships or the marketplace profile directory public. Different people at different times each omitted one line, and the framework chose the least safe outcome and gave no signal.

An audit of the platform found **78 view classes out of 356 with no `permission_classes`**. The ones that genuinely serve callers with no session are marked `AllowAny` explicitly in the PRs below. Every other view in that set stops answering anonymous callers when this merges, which is the point of the change.

`REST_FRAMEWORK` is process wide, so this is not scoped to the core: every app and service in `INSTALLED_APPS` is covered by the same setting.

## Steps to reproduce the bug/issue

On an unpatched checkout, with no session cookie and no `Authorization` header:

1. Pick any view in the 78 that declares no `permission_classes`, for example the lost-and-found categories route, and read it anonymously:

```console
$ curl -o /dev/null -w '%{http_code}' 'https://<host>/api/lost_and_found/categories/'
200
```

2. Confirm the cause rather than the symptom. `REST_FRAMEWORK` in `omniport/settings/third_party/drf.py` carries no `DEFAULT_PERMISSION_CLASSES`, so DRF falls back to its own `AllowAny`:

```console
$ grep -c DEFAULT_PERMISSION_CLASSES omniport/omniport/settings/third_party/drf.py
0
```

3. Set the default to `IsAuthenticated` and the same request returns 401, which is the intended behaviour and the reason every PR under "Ordering" must land first.

Note for whoever verifies this after deploy: `/api/lost_and_found/lostitem/` is **not** a valid check.
It declares `IsAuthenticatedOrReadOnly`, so the default never reaches it and it answers 200 before and after.
Use `categories/` or `recent_feed/`, which declare nothing.

## Steps done to fix it and test added for the same

### Ordering

Merge and deploy all of these first:

- IMGIITRoorkee/omniport-backend#227 - the nine logged-out views in this repository
- IMGIITRoorkee/omniport-backend-formula-one#19 - `EnsureCsrf`, `Hello`, `Manifest`
- IMGIITRoorkee/omniport-service-registration#2 - `CreateSession`, `SetPass`
- IMGIITRoorkee/omniport-service-maintainer-site#15 - the public site, plus closing an anonymous write path
- IMGIITRoorkee/omniport-service-gif#3 - `Roulette`
- IMGIITRoorkee/omniport-app-pseudoc#1 - `Registration`
- IMGIITRoorkee/omniport-app-gym-pravesh#12 - the OAuth callback and the four gym turnstile endpoints

### What will break, deliberately

The remaining views return 401 to callers with no session. Most hold institute data and should never have answered anonymously. A few are dead `hello_world` scaffolding left from the app template.

If an app turns out to need anonymous access to something not on the list above, the fix is to add `permission_classes = [AllowAny]` to that view, which is a one line change and now an explicit decision rather than an accident.

### The gym turnstile, added to the allow list during review

The turnstile at the gym door is not a browser. It presents no cookie and no JWT, and authenticates out of band inside the handler: `UserDetails` compares `?key=` against a deploy time `USER_SECRET_KEY`, `exit_all` compares a `password` in the body, `LogViewSet` writes the entry row in `create()` and closes it in `update()`, and `CurrentOccupancy` reads back the count the device displays.

DRF runs `check_permissions()` in `initial()`, before the handler, so this default rejected the device before any of those comparisons executed. gym-pravesh#12 originally allow-listed only the OAuth callback, which would have stopped gym entry and exit logging on deploy and decayed the occupancy the dashboard reads out of those rows to zero. That PR now declares all four device views `AllowAny`, preserving their existing checks.

Two pre-existing weaknesses there are recorded on that PR and are out of scope here: `LogViewSet` compares no secret at all, and `UserDetails` takes its shared secret as a query parameter, which writes it into nginx access logs on every scan.

### What this default cannot close

A project wide default only reaches views that leave `permission_classes` unset. Three shapes opt out of it, and an attribute based audit does not see them. These are not regressions and this PR does not make them worse, but they are the boundary of what it buys, and each needs its own change in its own repository.

**`@action(..., permission_classes=[])`.** The router merges the action's kwargs into `as_view()` and `ViewSetMixin.view()` does `setattr(self, 'permission_classes', [])` before `initial()` runs, so `check_permissions()` iterates an empty list. The class level permission above these actions is what makes an attribute scan count the viewset as already declared.

- `omniport-app-student-profile/views.py:138`, `:201`, `:337` - three `handle` actions that look up by `pk=enrolment_number`, a guessable key, and serve full name, enrolment number, branch, the institute webmail address (`serializers/profile.py:43`), `current_cgpa` when `show_cgpa` is set, and the display picture and resume URLs, plus `previous_education`, `achievement`, `experience`, `referee` and `social_link` for the same student. These stay anonymous after this merges.
- `omniport-app-faculty-profile/views.py:240` - a `handle` action that answers `"yes"` or `"no"` for whether a profile handle exists. An existence oracle rather than a PII leak, so lower severity than the three above, but it opts out of the default the same way.

**`get_permissions()` returning an empty sequence.** DRF reads the default only through `permission_classes`, so an override that returns `()` is unconditional public access for the actions it covers.

- `omniport-service-maintainer-site/views/hit.py:30` - the override returns `()` for every action except `list` and `retrieve`, so `POST`, `PATCH` and `DELETE /api/maintainer_site/hit/<handle>/` answer an anonymous caller. `APIView` is `csrf_exempt` and `SessionAuthentication.enforce_csrf` only runs once a session user is found, so CSRF does not intervene. maintainer-site#15 closes writes on `MaintainerInfoViewSet` and `MaintainerProjectView` but does not touch this file. Note that `update` has to stay open: `omniport-frontend-maintainer-site/src/components/team-individual-view.js:51` PUTs the view counter from the logged out public site, so only `create`, `partial_update` and `destroy` can be closed.
- `omniport-service-maintainer-site/views/project.py:27` - same shape, but its empty branch is `SAFE_METHODS` on the public site, so the behaviour is intended. Listed only because an attribute based audit cannot tell the two apart.

**A permission commented out.** `omniport-app-forminator/views/student_detail.py:43` - `StudentDetailListAccess`, routed as `POST /api/forminator/student_detail_list`, carries `# permission_classes = [IsForminator]` while `StudentDetailAccess` at line 15 in the same file declares it. It takes a list of user ids and returns name, enrolment number, branch, semester, gender, date of birth, reservation category, phone number, email address, home address, city, state, pincode, bhawan and room number for each. This merge downgrades it from anonymous to any-session rather than closing it; uncommenting line 43 closes it.

Separately, and also out of reach of any process wide default, the `IsAuthenticatedOrReadOnly` set deserves its own follow up. `omniport-app-buy-and-sell/views/sale_product_views.py:99` and `views/request_product_views.py:65` return the whole marketplace anonymously, and `SaleProductSerializer.get_person` (`serializers/sale_product.py:42`) embeds the seller's enrolment number, email address and, unless `is_phone_visible` is false, both phone numbers.

### Test plan

Ran against DRF 3.14.0, the pinned version, driving the real view modules through `APIRequestFactory` and `APIClient` with the backend's authentication classes and this default toggled:

- The four gym turnstile endpoints, each carrying its own credential and no session, reach their handler with the default absent, return 401 `"Authentication credentials were not provided."` with the default set and gym-pravesh#12 at its previous commit, and reach their handler again with that PR's new commit applied. A wrong `?key=` and a wrong `exit_all` password still return the app's own `"Authorization Error"`, so the allow-list did not widen anything.
- A `@action(permission_classes=[])` on a viewset whose class level permission is `IsAuthenticated` returns 200 to an anonymous caller while `retrieve` on the same viewset returns 401, confirming the student-profile and faculty-profile gap above.
- A `get_permissions()` returning `()` for the write actions answers an anonymous `PUT` with 200 and an anonymous `DELETE` with 204 under this default, confirming the maintainer-site gap above.

Still to run on staging, with every PR under "Ordering" already applied, before this merges:

- Load the login page cold in a fresh browser: branding, illustration roulette and the CSRF cookie must all come back.
- Sign in.
- Run password recovery end to end, from requesting the email to setting a new password.
- Complete a new user registration through the registration service.
- Load the maintainer site logged out.
- Sign in and confirm an ordinary session still reaches the apps it used to.
- Scan a card at the gym turnstile and confirm the entry row is written, the occupancy count moves, and scanning out closes the row.
- Then confirm the intended effect: with no session, `GET /api/lost_and_found/categories/` (`views/categories.py:9`) and `GET /api/lost_and_found/recent_feed/` (`views/recent_feed.py:6`) return 401 where they previously returned data. Both declare no permission of their own, so both flip.

Revert is a one line change on this file if anything unexpected surfaces.

## Criteria for issue to be resolved

- [ ] **Every PR under "Ordering" is merged and deployed first.** Merging this before them locks people out of the login page, password recovery, registration and the gym turnstile
- [ ] The login page loads cold in a fresh browser: branding, illustration roulette and the CSRF cookie
- [ ] Sign-in works
- [ ] Password recovery runs end to end, from requesting the email to setting a new password
- [ ] New-user registration works
- [ ] The four gym turnstile endpoints reach their handlers with their own credentials and no session
- [ ] A view declaring nothing, such as `lost_and_found/categories/`, returns 401 with no session
- [ ] A view declaring `AllowAny` still answers with no session
- [ ] An authenticated caller sees no change anywhere

*Reorganised to the five headings in `CONTRIBUTING.md`. The author's analysis, ordering list and test plan are preserved; the Summary lead, the reproduction steps and the checklist form of the criteria were added to fill headings the original did not carry. The merge-last warning is kept at the very top rather than demoted, since burying it would defeat its purpose.*