### PR TITLE
Declare the logged-out views public

### DIFF
--- a/omniport/core/base_auth/views/recover_passowrd.py
+++ b/omniport/core/base_auth/views/recover_passowrd.py
@@ -2,6 +2,7 @@ import swapper
 from django.core.cache import cache
 from rest_framework import generics, response, status
 from rest_framework.throttling import ScopedRateThrottle
+from rest_framework.permissions import AllowAny
 
 from base_auth.constants.password_recovery import (
     ACCOUNT_RATE_LIMIT,
@@ -44,6 +45,8 @@ class RecoverPassword(generics.GenericAPIView):
     Password recovery endpoint, rate limited per IP and per account, which
     responds identically whether or not the account exists
     """
+
+    permission_classes = [AllowAny]
 
     def get(self, request):
         """
@@ -159,6 +162,8 @@ class RecoverPassword(generics.GenericAPIView):
 
 
 class VerifyRecoveryToken(generics.GenericAPIView):
+
+    permission_classes = [AllowAny]
 
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'verify_recovery_token'

--- a/omniport/core/base_auth/views/reset_password.py
+++ b/omniport/core/base_auth/views/reset_password.py
@@ -1,4 +1,5 @@
 from rest_framework import status, generics, response
+from rest_framework.permissions import AllowAny
 
 from base_auth.serializers.reset_password import (
     ResetPasswordSerializer,
@@ -15,6 +16,8 @@ class ResetPassword(generics.GenericAPIView):
     the user in question and, when responding to a POST request, takes the
     username, the secret_answer and the new password to reset it
     """
+
+    permission_classes = [AllowAny]
 
     serializer_class = ResetPasswordSerializer
 

--- a/omniport/core/base_auth/views/verify_secret_answer.py
+++ b/omniport/core/base_auth/views/verify_secret_answer.py
@@ -1,5 +1,6 @@
 from rest_framework import status, generics, response
 from rest_framework.throttling import ScopedRateThrottle
+from rest_framework.permissions import AllowAny
 
 from base_auth.serializers.retrieve_user import (
     RetrieveUserSerializer,
@@ -15,6 +16,8 @@ class VerifySecretAnswer(generics.GenericAPIView):
     the user in question and, when responding to a POST request, takes the
     username, the secret_answer and the new password to reset it
     """
+
+    permission_classes = [AllowAny]
 
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'verify_secret_answer'

--- a/omniport/core/bootstrap/views/branding.py
+++ b/omniport/core/bootstrap/views/branding.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from rest_framework import generics
 from rest_framework import response
 from rest_framework import status
+from rest_framework.permissions import AllowAny
 
 from configuration.serializers.project.branding import BrandSerializer
 from configuration.serializers.project.site import SiteSerializer
@@ -11,6 +12,8 @@ class SiteBrandingView(generics.GenericAPIView):
     """
     Provide the branding information of the site as JSON to the frontend
     """
+
+    permission_classes = [AllowAny]
 
     serializer_class = SiteSerializer
 
@@ -32,6 +35,8 @@ class InstituteBrandingView(generics.GenericAPIView):
     Provide the branding information of the institute as JSON to the frontend
     """
 
+    permission_classes = [AllowAny]
+
     serializer_class = BrandSerializer
 
     def get(self, request, *args, **kwargs):
@@ -51,6 +56,8 @@ class MaintainersBrandingView(generics.GenericAPIView):
     """
     Provide the branding information of the maintainers as JSON to the frontend
     """
+
+    permission_classes = [AllowAny]
 
     serializer_class = BrandSerializer
 

--- a/omniport/core/session_auth/views/illustration_roulette.py
+++ b/omniport/core/session_auth/views/illustration_roulette.py
@@ -1,12 +1,15 @@
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
+from rest_framework.permissions import AllowAny
 
 
 class IllustrationRoulette(GenericAPIView):
     """
     Return the number of available illustrations to choose from
     """
+
+    permission_classes = [AllowAny]
 
     def get(self, request, *args, **kwargs):
         """

--- a/omniport/core/session_auth/views/login.py
+++ b/omniport/core/session_auth/views/login.py
@@ -1,5 +1,6 @@
 import swapper
 from rest_framework import status, generics, response
+from rest_framework.permissions import AllowAny
 
 from omniport.utils import switcher
 from session_auth.models import SessionMap
@@ -19,6 +20,8 @@ class Login(generics.GenericAPIView):
     This view takes the username and password and if correct, logs the user in
     via cookie-based session authentication
     """
+
+    permission_classes = [AllowAny]
 
     serializer_class = LoginSerializer
 


### PR DESCRIPTION
## Summary

Declares the nine logged-out views in this repository as `AllowAny`, which is what DRF already resolves them to.
Preparation for #226, which tightens the project default and would otherwise take the login page and account recovery down with it.

## Issue

The project sets no `DEFAULT_PERMISSION_CLASSES`, so DRF falls back to `AllowAny` and any view declaring no `permission_classes` answers unauthenticated requests. These nine genuinely do serve callers with no session, but by omission rather than by declaration.

A view that is public by omission is indistinguishable, to an audit and to the next reader, from one where the line was simply forgotten.
These nine are the ones that must stay reachable, and nothing in the code says so.

## Steps to reproduce the bug/issue

Not a defect at runtime, so the evidence is the declaration rather than a response.

1. On an unpatched checkout, none of the nine declares a permission:

```console
$ grep -c permission_classes omniport/core/session_auth/views/login.py
0
```

2. They answer anonymously all the same, DRF's fallback being `AllowAny`:

```console
$ curl -o /dev/null -w '%{http_code}' https://<host>/api/bootstrap/site_branding/
200
```

3. Set `DEFAULT_PERMISSION_CLASSES` to `IsAuthenticated` without this change and the login page, its artwork and the whole account recovery flow return 401.
Requiring a session to reach the login endpoint is circular, and account recovery exists precisely for people who cannot sign in.

## Steps done to fix it and test added for the same

Marking them explicitly changes no behaviour today, since they are already reachable without a session. It is preparation for tightening the project default, which would otherwise lock them along with everything else.

- `session_auth/views/login.py:Login`, requiring a session to reach the login endpoint is circular.
- `bootstrap/views/branding.py`, all three views draw the login page.
- `session_auth/views/illustration_roulette.py:IllustrationRoulette`, supplies that page's artwork.
- `base_auth/views/recover_passowrd.py`, `RecoverPassword` and `VerifyRecoveryToken`.
- `base_auth/views/reset_password.py:ResetPassword` and `base_auth/views/verify_secret_answer.py:VerifySecretAnswer`.

The four `base_auth` views are account recovery, which exists precisely for people who cannot sign in.

### Ordering

Part of a coordinated change across repositories. This must merge **before** #226, which tightens the default.

### Test plan

- Each of the nine responds exactly as before, with and without a session.
- The login page loads cold in a fresh browser: branding, roulette, sign-in.
- Password recovery runs end to end, from requesting the email to setting a new password.
- No view gains or loses a route, serializer, throttle or queryset. The `permission_classes` line sits below each class docstring, so no docstring is displaced into a bare string statement.
- All changed files compile.

## Criteria for issue to be resolved

- [ ] Each of the nine responds exactly as before, with and without a session
- [ ] The login page loads cold in a fresh browser: branding, roulette, sign-in
- [ ] Password recovery runs end to end, from requesting the email to setting a new password
- [ ] No view gains or loses a route, serializer, throttle or queryset
- [ ] Each `permission_classes` line sits below its class docstring, so no docstring is displaced into a bare string statement
- [ ] All changed files compile
- [ ] Merged and deployed before #226

*Reorganised to the five headings in `CONTRIBUTING.md`. The author's analysis and test plan are preserved; the Summary lead, the reproduction steps and the checklist form of the criteria were added to fill headings the original did not carry.*