### PR TITLE
Throttle every API endpoint and pin the throttle to the real client IP

### DIFF
--- a/omniport/core/session_auth/views/media_authorisation.py
+++ b/omniport/core/session_auth/views/media_authorisation.py
@@ -17,6 +17,9 @@ class MediaAuthorisation(APIView):
     """
 
     permission_classes = [IsAuthenticated]
+    # nginx sub-requests once per protected file, so a page of media would
+    # otherwise spend the caller's whole rate budget on a view serving no data
+    throttle_classes = []
 
     def get(self, request, *args, **kwargs):
         """

--- a/omniport/core/session_auth/views/media_authorisation.py
+++ b/omniport/core/session_auth/views/media_authorisation.py
@@ -17,8 +17,6 @@ class MediaAuthorisation(APIView):
     """
 
     permission_classes = [IsAuthenticated]
-    # nginx sub-requests once per protected file, so a page of media would
-    # otherwise spend the caller's whole rate budget on a view serving no data
     throttle_classes = []
 
     def get(self, request, *args, **kwargs):

--- a/omniport/core/token_auth/models/app_access_token.py
+++ b/omniport/core/token_auth/models/app_access_token.py
@@ -10,6 +10,10 @@ class AppAccessToken(Model):
     request
     """
 
+    # AppAccessTokenAuthentication puts an instance of this on request.user, so
+    # it has to answer what permissions, throttles and middleware ask of a user
+    is_authenticated = True
+
     app_name = models.CharField(
         max_length=63, 
         blank=True,

--- a/omniport/omniport/middleware/ip_address_rings.py
+++ b/omniport/omniport/middleware/ip_address_rings.py
@@ -27,7 +27,8 @@ class IpAddressRings:
         """
 
         # Extract IP from proxy headers (set by NGINX) or direct connection.
-        # X-Forwarded-For may be a comma-separated list; take the first entry.
+        # NGINX appends the peer to X-Forwarded-For, so only the last entry of
+        # that list is one the client cannot forge
         raw_ip = request.META.get(
             'HTTP_X_REAL_IP',
             request.META.get(
@@ -35,7 +36,7 @@ class IpAddressRings:
                 request.META.get('REMOTE_ADDR', 'Not Found')
             )
         )
-        ip_address = raw_ip.split(',')[0].strip()
+        ip_address = raw_ip.split(',')[-1].strip()
         try:
             ipaddress.ip_address(ip_address)
         except ValueError:

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -33,14 +33,10 @@ REST_FRAMEWORK = {
         'rest_framework.throttling.UserRateThrottle',
     ],
     'DEFAULT_THROTTLE_RATES': {
-        # A floor above real browsing, which costs 23 requests per page mount.
-        # Views serving bulk personal data need their own throttle_scope
         'anon': '2000/hour',
         'user': '5000/hour',
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',
     },
-    # NGINX appends the peer address to X-Forwarded-For, making the last entry
-    # the only one a client cannot forge to mint itself a fresh throttle bucket
     'NUM_PROXIES': 1,
 }

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -29,9 +29,18 @@ REST_FRAMEWORK = {
     # ScopedRateThrottle only applies to views that declare a throttle_scope
     'DEFAULT_THROTTLE_CLASSES': [
         'rest_framework.throttling.ScopedRateThrottle',
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle',
     ],
     'DEFAULT_THROTTLE_RATES': {
+        # A floor above real browsing, which costs 23 requests per page mount.
+        # Views serving bulk personal data need their own throttle_scope
+        'anon': '2000/hour',
+        'user': '5000/hour',
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',
     },
+    # NGINX appends the peer address to X-Forwarded-For, making the last entry
+    # the only one a client cannot forge to mint itself a fresh throttle bucket
+    'NUM_PROXIES': 1,
 }


### PR DESCRIPTION
## Summary

PR #214 wired `DEFAULT_THROTTLE_CLASSES` with `ScopedRateThrottle`, which only applies to a view that declares a `throttle_scope`. Two account recovery views declare one. Everything else in the platform, including every endpoint that pages through personal data, is unbounded.

This PR:

- Adds `AnonRateThrottle` and `UserRateThrottle` to the defaults, at `2000/hour` and `5000/hour`. Apps and services are cloned into `omniport/apps` and `omniport/services` at deploy time, so the backend's DRF settings are the only place a default reaches all of them, the same leverage `DEFAULT_PERMISSION_CLASSES` has. `ScopedRateThrottle` stays first so a view can still declare a tighter scope.
- Sets `NUM_PROXIES = 1`. With it unset, DRF's `get_ident` returns the entire `X-Forwarded-For` string. NGINX sets `X-Forwarded-For $proxy_add_x_forwarded_for`, which appends the peer to whatever the caller sent, so the caller controls a prefix of the bucket key and can mint a fresh bucket per request. `NUM_PROXIES = 1` reads the last entry, the one NGINX wrote. This also closes the bypass on the two throttles #214 already shipped: 200 of 200 attempts got through the `5/hour` secret answer throttle by rotating the header.
- Reads the same end of the list in `IpAddressRings`, which sets `request.source_ip_address`. That value gates the app access token IP allow list in `AppAccessTokenAuthentication` and the admin route restriction in `RoutesControl`, so taking the caller supplied end of the header there is an authorisation question, not only a throttling one.
- Exempts `MediaAuthorisation`. NGINX `auth_request`s it once per protected file, so a media heavy page would spend the caller's whole budget on a view that returns an empty body, and every request over the limit turns into a broken image.
- Gives `AppAccessToken` an `is_authenticated` attribute. `AppAccessTokenAuthentication` puts an instance of that plain model on `request.user`, and both new throttles ask `request.user.is_authenticated`, so without it every app token request 500s. Four views authenticate that way: `VerifyInstituteSecurityKey` and `RetrieveInstituteSecurityKey` here, `GateViewSetExternal` and `GetTrip` in r-pravesh.

### How the rates were chosen

Measured against the SPA rather than picked round. The heaviest page mount in the frontend repositories is a student profile: `fetchAppDetails` (2), nine generic list components each fetching on mount (9), `profile` (2), `skill` (1), `linkDisplay` (1), plus the shell's app list, four branding calls, `whoAmI`, notifications and the footer branding (8). 23 requests. Logged out pages cost the 8 shell requests. Both rates clear a mount every 36 seconds for a solid hour, twice over.

Nothing polls. The only `setInterval` across the frontend repositories is a countdown in the registration OTP form. The maintainer site hit counter is one PUT per profile view. `DefaultDP` fetches from Gravatar, not from us. The one per asset caller is `MediaAuthorisation`, exempted above. NGINX already limits per IP at `rate=16r/s burst=24`, which a 23 request mount sits inside, so these rates do not narrow anything the deployment does not already allow.

### What this does not close

`people_search`'s `LargeResultsSetPagination` sets `page_size_query_param = 'page_size'` with `max_page_size = 1000`, so `?page_size=1000` pulls a 25,000 row directory in 25 requests. No rate a real user can live with is below that. The global throttle is a floor; closing the directory endpoints needs a `throttle_scope` and a smaller `max_page_size` on those views in `omniport-app-people-search`, and the scope's rate has to be added here first or DRF raises `ImproperlyConfigured`.

## Test plan

No test suite in this repository, so this was driven through a throwaway Django 4.1.5 / DRF 3.14.0 harness that loads the real `REST_FRAMEWORK` dict from `settings/third_party/drf.py`, the real `MediaAuthorisation` view, the real `people_search` pagination class, and the real `AppAccessToken` class body, and drives them through a client that reproduces `$proxy_add_x_forwarded_for`.

`py_compile` passes on all four changed files.

| | before | after |
| --- | --- | --- |
| Authenticated enumeration, 25,000 rows at `PAGE_SIZE` 10 | 2500 pages, 25000 records | 2500 pages, 25000 records, still open |
| Authenticated sustained enumeration, 8000 requests | 8000 allowed | 5000 allowed |
| `verify_secret_answer` (`5/hour`) with rotating `X-Forwarded-For` | 200 of 200 allowed | 5 allowed |
| Same, without the header (control) | 5 allowed | 5 allowed |
| Anonymous enumeration with rotating `X-Forwarded-For`, 4000 requests | 4000 allowed | 2000 allowed |
| `LargeResultsSetPagination` with `page_size=1000` | 25 requests, 25000 records | 25 requests, 25000 records, still open |
| App access token view | HTTP 200 | HTTP 200 |
| 5100 `auth_request` sub-requests, then 10 directory pages | 5100 served, 10 pages | 5100 served, 10 pages |

Each fix was also run against a tree holding only that one change back, to confirm it is load bearing rather than incidental:

- Throttles on, `AppAccessToken` without `is_authenticated`: the app token view returns HTTP 500. With it, HTTP 200.
- Throttles on, `MediaAuthorisation` without the exemption: 5000 of 5100 sub-requests served, and 0 of the following 10 directory pages. With it, 5100 and 10.
- `IpAddressRings` exercised directly: through NGINX both revisions read the peer, `10.11.1.200`. With `X-Real-IP` absent and `X-Forwarded-For: 203.0.113.9, 10.11.1.200`, the old code returns `203.0.113.9` and the new code returns `10.11.1.200`.

Not covered: the throttles read the `default` cache, which is memcached in this deployment. A memcached outage now surfaces on every request rather than only on password recovery.
