### PR TITLE
Add the people_search throttle rate

### DIFF
--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -33,5 +33,8 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',
+        # Directory listings, capped at 30 rows a page, so this also bounds how
+        # fast the people search endpoints can be scraped
+        'people_search': '500/hour',
     },
 }

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -33,8 +33,6 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',
-        # Directory listings, capped at 30 rows a page, so this also bounds how
-        # fast the people search endpoints can be scraped
         'people_search': '500/hour',
     },
 }


### PR DESCRIPTION
## Summary

Adds `people_search: '500/hour'` to `DEFAULT_THROTTLE_RATES`.

IMGIITRoorkee/omniport-app-people-search#14 caps the directory page size at 30 rows and declares `throttle_scope = 'people_search'` on the student and faculty search viewsets, so those endpoints can carry a rate distinct from general browsing. `ScopedRateThrottle` raises `ImproperlyConfigured` for a scope with no entry here, so the two PRs have to land and deploy together. Neither should be merged alone.

500 an hour is well above what the people search UI costs. A search is one request, or two in the combined tab, and the input is debounced at 500 ms, so a heavy session is tens of requests. At the new 30 row cap the scope bounds a directory scrape to 15,000 rows an hour, against the whole ~25,000 row directory in about 25 requests today.

## Test plan

Ran a throwaway harness that mounts a DRF viewset declaring `throttle_scope = 'people_search'` and loads `DEFAULT_THROTTLE_RATES` from this file, driven with `APIClient`.

- With this branch's settings: requests 1 through 500 returned 200 and request 501 returned 429.
- With master's settings, the same viewset raises `ImproperlyConfigured: No default throttle rate set for 'people_search' scope`, confirming the ordering constraint above.
- `py_compile` on `omniport/omniport/settings/third_party/drf.py`.