### PR TITLE
Give the password endpoints a throttle of their own

### DIFF
--- a/omniport/core/base_auth/views/reset_password.py
+++ b/omniport/core/base_auth/views/reset_password.py
@@ -16,8 +16,6 @@ class ResetPassword(generics.GenericAPIView):
     username, the secret_answer and the new password to reset it
     """
 
-    # Checks the secret answer without going through verify_secret_answer, so
-    # it needs a scope of its own or it is the unthrottled way in to that check
     throttle_scope = 'reset_password'
     serializer_class = ResetPasswordSerializer
 

--- a/omniport/core/base_auth/views/reset_password.py
+++ b/omniport/core/base_auth/views/reset_password.py
@@ -16,6 +16,9 @@ class ResetPassword(generics.GenericAPIView):
     username, the secret_answer and the new password to reset it
     """
 
+    # Checks the secret answer without going through verify_secret_answer, so
+    # it needs a scope of its own or it is the unthrottled way in to that check
+    throttle_scope = 'reset_password'
     serializer_class = ResetPasswordSerializer
 
     def post(self, request, *args, **kwargs):

--- a/omniport/core/session_auth/views/login.py
+++ b/omniport/core/session_auth/views/login.py
@@ -20,6 +20,9 @@ class Login(generics.GenericAPIView):
     via cookie-based session authentication
     """
 
+    # Shared with token_auth.views.ObtainPair so that alternating between the
+    # two password endpoints cannot draw twice the budget
+    throttle_scope = 'login'
     serializer_class = LoginSerializer
 
     def post(self, request, *args, **kwargs):

--- a/omniport/core/session_auth/views/login.py
+++ b/omniport/core/session_auth/views/login.py
@@ -20,8 +20,6 @@ class Login(generics.GenericAPIView):
     via cookie-based session authentication
     """
 
-    # Shared with token_auth.views.ObtainPair so that alternating between the
-    # two password endpoints cannot draw twice the budget
     throttle_scope = 'login'
     serializer_class = LoginSerializer
 

--- a/omniport/core/token_auth/views.py
+++ b/omniport/core/token_auth/views.py
@@ -32,6 +32,7 @@ class ObtainPair(TokenObtainPairView):
     Remove the effect of the addition of project-wide JSON API from the view
     """
 
+    throttle_scope = 'login'
     parser_classes = PARSERS_MINUS_JSON_API
     renderer_classes = RENDERERS_MINUS_JSON_API
 

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -37,6 +37,10 @@ REST_FRAMEWORK = {
         # Views serving bulk personal data need their own throttle_scope
         'anon': '2000/hour',
         'user': '5000/hour',
+        # Anonymous buckets key on IP, and a shared campus egress address draws
+        # the whole institute from one, so this sits well above peak real logins
+        'login': '300/hour',
+        'reset_password': '5/hour',
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',
     },

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -37,8 +37,6 @@ REST_FRAMEWORK = {
         # Views serving bulk personal data need their own throttle_scope
         'anon': '2000/hour',
         'user': '5000/hour',
-        # Anonymous buckets key on IP, and a shared campus egress address draws
-        # the whole institute from one, so this sits well above peak real logins
         'login': '300/hour',
         'reset_password': '5/hour',
         'verify_secret_answer': '5/hour',


### PR DESCRIPTION
Stacked on #230, which is where the throttle configuration lives. Merge #230 first; this branch targets it and will retarget to `master` on its own once #230 lands.

## What this changes

The three endpoints that take a credential from an anonymous caller carried no rate of their own, so their whole budget was the general anonymous floor #230 introduces: 2000 requests per hour per IP, which is sized for browsing, not for guessing.

- `session_auth.views.login.Login` and `token_auth.views.ObtainPair` both declare `throttle_scope = 'login'`. One scope, not two, so that alternating between the two password endpoints cannot draw twice the budget.
- `base_auth.views.reset_password.ResetPassword` declares `throttle_scope = 'reset_password'`. It checks the secret answer itself rather than requiring a prior call to `verify_secret_answer`, so the 5/hour scope #214 put on that endpoint could be walked around by posting straight here. Each wrong answer also increments `failed_reset_attempts`, which locks an account out of password recovery for good at three, so an unthrottled route in is a way to disable recovery across the roster.
- `DEFAULT_THROTTLE_RATES` gains `login` at 300/hour and `reset_password` at 5/hour, matching the 5/hour `verify_secret_answer` already carries.

## Why 300/hour for login

Anonymous throttle buckets key on the client address, so every user behind a shared campus egress address draws from one bucket. Sessions are cookie sessions with Django's two week default age, so a 10,000 user institute produces on the order of 30 logins an hour in steady state even if all of it arrives from a single address. 300/hour leaves roughly ten times that headroom while cutting the guessing budget from 2000, and a user who mistypes a password five times is nowhere near it.

The choice is bounded by the same keying in the other direction: a per user number such as 5/hour is not available on an IP keyed bucket, because a lab, a hostel or the institute egress would share it. A control that does not depend on the source address, keyed on the submitted username, is the complement to this, and it is a separate change since the shape of it, whether guessing against one account should slow down or lock out, is a product decision.

## Test plan

Ran against this branch, with the real `Login`, `ObtainPair` and `ResetPassword` classes loaded from the working tree and driven through a real DRF request pipeline configured from this repository's `REST_FRAMEWORK` dict. Attempts accepted per hour from one client address:

| | before | after |
| --- | --- | --- |
| `session_auth/login/` | 2000 | 300 |
| `token_auth/obtain_pair/` | 2000 | 300 |
| the two alternating | 2000 | 300 |
| `base_auth/reset_password/` | 2000 | 5 |

Also checked that six consecutive wrong passwords from one address are all answered normally rather than throttled, and that the two login endpoints share a single bucket rather than holding one each. `py_compile` passes on all four changed files.
