### PR TITLE
Throttle the OAuth credential endpoints

### DIFF
--- a/omniport/core/open_auth/http_urls.py
+++ b/omniport/core/open_auth/http_urls.py
@@ -1,14 +1,15 @@
 from django.urls import path, include
-from django.views.decorators.http import require_POST
 from oauth2_provider.views import (
     AuthorizationView,
     TokenView,
     RevokeTokenView,
 )
 from rest_framework import routers
+from rest_framework.authentication import SessionAuthentication
 
 from open_auth.views.application import ApplicationViewSet
 from open_auth.views.retrieve_data import GetUserData
+from open_auth.views.throttling import ThrottledOAuthLibView
 
 router = routers.SimpleRouter()
 router.register('application', ApplicationViewSet, basename='application')
@@ -18,17 +19,26 @@ app_name = 'open_auth'
 urlpatterns = [
     path(
         'authorise/',
-        require_POST(AuthorizationView.as_view()),
+        ThrottledOAuthLibView.as_view(
+            oauthlib_view=AuthorizationView.as_view(),
+            # DRF replaces request.user with the anonymous user when no
+            # authenticator matches, and the consent screen needs the session
+            authentication_classes=[SessionAuthentication],
+        ),
         name='authorise'
     ),
     path(
         'token/',
-        TokenView.as_view(),
+        ThrottledOAuthLibView.as_view(
+            oauthlib_view=TokenView.as_view(),
+        ),
         name='token'
     ),
     path(
         'revoke_token/',
-        RevokeTokenView.as_view(),
+        ThrottledOAuthLibView.as_view(
+            oauthlib_view=RevokeTokenView.as_view(),
+        ),
         name='revoke_token'
     ),
     path(

--- a/omniport/core/open_auth/views/throttling.py
+++ b/omniport/core/open_auth/views/throttling.py
@@ -1,0 +1,27 @@
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
+
+
+class ThrottledOAuthLibView(APIView):
+    """
+    View that runs the DRF throttle stack in front of a django-oauth-toolkit
+    view, which is a plain Django view and is otherwise reached without one
+    """
+
+    authentication_classes = []
+    permission_classes = [AllowAny]
+    oauthlib_view = None
+    throttle_scope = 'open_auth'
+
+    def post(self, request, *args, **kwargs):
+        """
+        View to serve POST requests
+        :param request: the request that is to be responded to
+        :param args: arguments
+        :param kwargs: keyword arguments
+        :return: whatever the wrapped django-oauth-toolkit view returns
+        """
+
+        # The toolkit view reads the form body itself, and nothing above has
+        # consumed the stream, so hand it the untouched Django request
+        return self.oauthlib_view(request._request, *args, **kwargs)

--- a/omniport/core/session_auth/views/media_authorisation.py
+++ b/omniport/core/session_auth/views/media_authorisation.py
@@ -1,6 +1,7 @@
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
+from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
 
@@ -17,7 +18,8 @@ class MediaAuthorisation(APIView):
     """
 
     permission_classes = [IsAuthenticated]
-    throttle_classes = []
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'media_authorisation'
 
     def get(self, request, *args, **kwargs):
         """

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -37,6 +37,8 @@ REST_FRAMEWORK = {
         'user': '5000/hour',
         'login': '300/hour',
         'reset_password': '5/hour',
+        'open_auth': '1000/hour',
+        'media_authorisation': '20000/hour',
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',
         'people_search': '500/hour',


### PR DESCRIPTION
## Summary

Adds DRF throttling to the OAuth endpoints (`authorise/`, `token/`, `revoke_token/`) which previously bypassed DRF throttles and were limited only by NGINX.

- Adds `ThrottledOAuthLibView` to apply DRF throttles while preserving django-oauth-toolkit behavior.
- Adds `open_auth` throttling at **1000 requests/hour**.
- Preserves session and CSRF handling for `authorise/`.
- Adds a separate **20,000 requests/hour** throttle for `media_authorisation` to account for NGINX sub-requests.
- Removes redundant `require_POST` from `authorise/`.

## Testing

- OAuth credential/password/client-secret attempts are capped at **1000/hour** per calling address.
- Valid authorization-code, consent, and password-grant flows remain unaffected.
- CSRF protection for the consent flow remains intact.
- `media_authorisation` is capped at **20,000/hour** without affecting normal requests after 6000 sub-requests.
- `python -m compileall omniport/core omniport` passes.