### PR TITLE
Give the credential endpoints a throttle of their own

### DIFF
--- a/omniport/core/base_auth/views/reset_password.py
+++ b/omniport/core/base_auth/views/reset_password.py
@@ -19,6 +19,7 @@ class ResetPassword(generics.GenericAPIView):
 
     permission_classes = [AllowAny]
 
+    throttle_scope = 'reset_password'
     serializer_class = ResetPasswordSerializer
 
     def post(self, request, *args, **kwargs):

--- a/omniport/core/session_auth/views/login.py
+++ b/omniport/core/session_auth/views/login.py
@@ -23,6 +23,7 @@ class Login(generics.GenericAPIView):
 
     permission_classes = [AllowAny]
 
+    throttle_scope = 'login'
     serializer_class = LoginSerializer
 
     def post(self, request, *args, **kwargs):

--- a/omniport/core/token_auth/views.py
+++ b/omniport/core/token_auth/views.py
@@ -32,6 +32,7 @@ class ObtainPair(TokenObtainPairView):
     Remove the effect of the addition of project-wide JSON API from the view
     """
 
+    throttle_scope = 'login'
     parser_classes = PARSERS_MINUS_JSON_API
     renderer_classes = RENDERERS_MINUS_JSON_API
 

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -35,6 +35,8 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'anon': '2000/hour',
         'user': '5000/hour',
+        'login': '300/hour',
+        'reset_password': '5/hour',
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',
         'people_search': '500/hour',


### PR DESCRIPTION
### Summary

`Login`, `ObtainPair` and `ResetPassword` declare no `throttle_scope`, so they fall to the general anonymous rate of 2000 an hour per address that #230 introduced. That is a reasonable floor for browsing and a poor ceiling for guessing credentials.

- `session_auth.views.Login` and `token_auth.views.ObtainPair` share the scope `login` at 300 an hour, deliberately one bucket rather than two, so that alternating between the two password endpoints cannot draw twice the budget.
- `base_auth.views.ResetPassword` takes `reset_password` at 5 an hour, matching `verify_secret_answer`, because it performs the same secret answer check without going through that view and would otherwise be the unthrottled way to reach it.

`Refresh` and `Verify` are deliberately left alone. They take a token the caller already holds rather than a credential, and a legitimate client refreshes far more often than it logs in.

### Why this exists

This is a rebase of #232. That pull request reports as merged, but none of its five lines are on `master`.

It was opened against `security/global-request-throttling`, the branch of #230, rather than against `master`. #230 merged to `master` at 20:02:54 and #232 merged into that already merged branch at 20:03:24, so its changes went into a branch that was no longer on the path to `master`.

Confirmed rather than inferred:

```console
$ git merge-base --is-ancestor eec6605 origin/master; echo $?
1

$ git show origin/master:omniport/core/session_auth/views/login.py | grep -c throttle_scope
0
```

The content here is #232's, reapplied to current `master` by hand rather than cherry picked, because #232's branch predates #227 and #231 and a cherry pick would have reverted the `AllowAny` declarations and the `people_search` rate. The diff is five insertions and no deletions, matching #232's own stat.

### Sizing

300 an hour per address. Anonymous throttles key on IP, and a shared campus egress address can put a large part of the institute behind one, so this sits well above peak real logins while cutting the current ceiling by roughly seven times. It is one line in `DEFAULT_THROTTLE_RATES` if it proves tight.

The complement this does not provide is a limiter keyed on the submitted username, which is what bounds guessing against a single account regardless of source address. Worth considering separately.

### Test plan

- `POST /session_auth/login/` with wrong credentials returns 401 up to the limit and 429 past it, from one address.
- Alternating between `/session_auth/login/` and `/token_auth/obtain_pair/` draws from the same bucket rather than two.
- `POST /base_auth/reset_password/` returns 429 after 5 attempts in an hour.
- `/token_auth/refresh/` and `/token_auth/verify/` are unaffected and keep working at browsing volume.
- A user who mistypes a password a few times and then succeeds is not blocked.