### PR TITLE
Record app entry and access to personal data in the audit trail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,11 @@ jobs:
         # code does.
         python-version: '3.10'
 
+    # The middleware reads Django settings, so the suite needs it importable.
+    # Pinned to the version in poetry.lock rather than the constraint.
+    - name: Install Django
+      run: python -m pip install "django==4.1.5"
+
     - name: Run the test suite
       run: python -m unittest discover --start-directory tests --verbose
 

--- a/omniport/omniport/constants.py
+++ b/omniport/omniport/constants.py
@@ -5,3 +5,7 @@ This file defines the constants used across the project itself
 # The URL namespaces whose views are worth an audit record
 AUTHENTICATION_NAMESPACE_SUFFIX = '_auth'
 ADMIN_NAMESPACE = 'admin'
+
+
+# The session key under which each app's most recent entry date is kept
+APP_ENTRY_SESSION_KEY = 'opened_apps'

--- a/omniport/omniport/middleware/auth_security.py
+++ b/omniport/omniport/middleware/auth_security.py
@@ -2,9 +2,13 @@
 Middleware that keeps an audit trail of the security relevant requests
 """
 
+from django.conf import settings
+from django.utils import timezone
+
 from core.utils.logs import get_logging_function
 from omniport.constants import (
     ADMIN_NAMESPACE,
+    APP_ENTRY_SESSION_KEY,
     AUTHENTICATION_NAMESPACE_SUFFIX,
 )
 
@@ -16,6 +20,11 @@ class AuditLoggingMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
+        self.namespaces = frozenset(
+            configuration.nomenclature.name
+            for _, configuration in settings.DISCOVERY.apps
+            + settings.DISCOVERY.services
+        )
 
     def __call__(self, request):
         response = self.get_response(request)
@@ -40,6 +49,17 @@ class AuditLoggingMiddleware:
                 user
             )
 
+        app_name = self.discovered_namespace(request)
+        if app_name is not None:
+            auth_security_log(
+                f'{request.method} {request.get_full_path()} '
+                f'returned status {response.status_code}',
+                'info',
+                user
+            )
+            if user is not None:
+                self.log_app_entry(request, app_name, user)
+
         return response
 
     @staticmethod
@@ -58,3 +78,43 @@ class AuditLoggingMiddleware:
             app_name.endswith(AUTHENTICATION_NAMESPACE_SUFFIX)
             or app_name == ADMIN_NAMESPACE
         )
+
+    def discovered_namespace(self, request):
+        """
+        The discovered app or service that served the request, if any.
+        Authentication namespaces are refused because these lines keep the
+        query string, which for them carries OAuth codes and tokens
+        """
+
+        name = getattr(request.resolver_match, 'app_name', None)
+        if name is None or name.endswith(AUTHENTICATION_NAMESPACE_SUFFIX):
+            return None
+        return name if name in self.namespaces else None
+
+    @staticmethod
+    def first_entry_of_the_day(opened, app_name, today):
+        """
+        Whether this is the session's first request to the app today, which is
+        what turns a stream of requests into one record of the app being used
+        """
+
+        return opened.get(app_name) != today
+
+    def log_app_entry(self, request, app_name, user):
+        """
+        Record a session opening an app, skipping the request-per-request
+        repetition that would otherwise bury the record it is kept for
+        """
+
+        session = getattr(request, 'session', None)
+        if session is None or not session.session_key:
+            return
+
+        today = timezone.localdate().isoformat()
+        opened = session.get(APP_ENTRY_SESSION_KEY, {})
+        if not self.first_entry_of_the_day(opened, app_name, today):
+            return
+
+        opened[app_name] = today
+        session[APP_ENTRY_SESSION_KEY] = opened
+        auth_security_log(f'Opened {app_name}', 'info', user)

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -1,0 +1,153 @@
+"""
+Tests for the namespaces the request audit trail covers
+
+These import the middleware directly rather than through Django, so they run
+in a bare interpreter with no settings module and no database.
+"""
+
+import pathlib
+import sys
+import types
+import unittest
+import unittest.mock
+
+import django.conf
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / 'omniport'))
+
+# localdate() reads these two; nothing else here touches the settings module
+if not django.conf.settings.configured:
+    django.conf.settings.configure(USE_TZ=True, TIME_ZONE='Asia/Kolkata')
+
+from omniport.constants import APP_ENTRY_SESSION_KEY
+from omniport.middleware.auth_security import AuditLoggingMiddleware
+
+
+# Two discovered names and one authentication namespace, which never is one
+DISCOVERED = frozenset({'bhawan_app', 'common_biodata'})
+
+
+def middleware_over(namespaces=DISCOVERED):
+    """
+    An instance built without __init__, which would need live settings
+    """
+
+    middleware = AuditLoggingMiddleware.__new__(AuditLoggingMiddleware)
+    middleware.namespaces = namespaces
+    return middleware
+
+
+def request_for(app_name):
+    """
+    Build the smallest stand-in for a request that the predicate reads, where
+    an app_name of None is a path that resolved to no view at all
+    """
+
+    resolver_match = (
+        None if app_name is None else types.SimpleNamespace(app_name=app_name)
+    )
+    return types.SimpleNamespace(resolver_match=resolver_match)
+
+
+class StubSession(dict):
+    """
+    A session that records nothing more than the middleware reads from one
+    """
+
+    def __init__(self, session_key='a-session-key'):
+        super().__init__()
+        self.session_key = session_key
+
+
+class AppEntryTestCase(unittest.TestCase):
+    """
+    Tests for AuditLoggingMiddleware.log_app_entry
+    """
+
+    def setUp(self):
+        self.logged = []
+        self.middleware = AuditLoggingMiddleware.__new__(AuditLoggingMiddleware)
+        self.session = StubSession()
+        self.request = types.SimpleNamespace(session=self.session)
+
+    def enter(self, app_name):
+        with unittest.mock.patch(
+            'omniport.middleware.auth_security.auth_security_log',
+            lambda message, level, user: self.logged.append(message),
+        ):
+            self.middleware.log_app_entry(self.request, app_name, user=object())
+
+    def test_first_entry_is_logged(self):
+        self.enter('bhawan_app')
+        self.assertEqual(self.logged, ['Opened bhawan_app'])
+
+    def test_repeat_entry_the_same_day_is_not_logged(self):
+        for _ in range(5):
+            self.enter('bhawan_app')
+        self.assertEqual(self.logged, ['Opened bhawan_app'])
+
+    def test_a_second_app_is_logged_separately(self):
+        self.enter('bhawan_app')
+        self.enter('noticeboard')
+        self.assertEqual(
+            self.logged, ['Opened bhawan_app', 'Opened noticeboard']
+        )
+
+    def test_a_new_day_is_logged_again(self):
+        self.enter('bhawan_app')
+        self.session[APP_ENTRY_SESSION_KEY]['bhawan_app'] = '1970-01-01'
+        self.enter('bhawan_app')
+        self.assertEqual(self.logged, ['Opened bhawan_app'] * 2)
+
+    def test_a_request_without_a_session_is_not_logged(self):
+        self.request.session = StubSession(session_key=None)
+        self.enter('bhawan_app')
+        self.assertEqual(self.logged, [])
+
+
+class DiscoveredNamespaceTestCase(unittest.TestCase):
+    """
+    Tests for AuditLoggingMiddleware.discovered_namespace
+    """
+
+    def setUp(self):
+        self.middleware = middleware_over()
+
+    def test_every_discovered_name_is_covered(self):
+        for namespace in DISCOVERED:
+            with self.subTest(namespace=namespace):
+                self.assertEqual(
+                    self.middleware.discovered_namespace(
+                        request_for(namespace)
+                    ),
+                    namespace,
+                )
+
+    def test_undiscovered_name_is_not_covered(self):
+        self.assertIsNone(
+            self.middleware.discovered_namespace(request_for('nonesuch'))
+        )
+
+    def test_unresolved_path_is_not_covered(self):
+        self.assertIsNone(
+            self.middleware.discovered_namespace(request_for(None))
+        )
+
+    def test_authentication_namespace_is_never_covered(self):
+        """
+        These lines keep the query string, which for an authentication app
+        would write OAuth codes and tokens to disk. The core auth apps live
+        outside the discovered directories today; this refuses them anyway,
+        so the protection does not rest on where a directory happens to sit
+        """
+
+        middleware = middleware_over(DISCOVERED | {'open_auth'})
+        self.assertIsNone(
+            middleware.discovered_namespace(request_for('open_auth'))
+        )
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description**
[feature] Extends `AuditLoggingMiddleware` so the audit trail can answer two questions it previously could not: which apps a person opened, and what they requested from them.

Before this, the trail recorded logins, logouts, authorisation failures and admin-site use. A `403` on a student roster was logged; a `200` was not. Nothing recorded which apps a person visited at all.

**Fixes**
No issue filed.

**Technical**

*Coverage comes from discovery, not from a list*

Every discovered app and service is covered, built once at startup from `settings.DISCOVERY`. An app added tomorrow is recorded without anyone touching this file.

An earlier revision of this branch used a hand-maintained allow list. It was dropped because it carried its own evidence against itself: it named `student_biodata` and `faculty_biodata`, neither of which declares an `app_name`, so those entries could never have matched. A list somebody must remember to extend fails exactly when the app that needed watching is the one nobody added.

Services are included deliberately, not incidentally. `common_biodata`, `student_biodata` and `faculty_biodata` are services rather than apps, and they hold personal data.

*Authentication namespaces are refused explicitly*

These lines keep the query string via `get_full_path()`, because the filter parameters decide which records were disclosed. For an authentication app that same query string is an OAuth `code` or `state` written to disk.

Core apps (`open_auth`, `session_auth`, `base_auth`, `token_auth`) live under `omniport/core/`, outside both discovered directories, so they could never match anyway. The check refuses them regardless: the directory layout that makes this safe today is not a guarantee, and `test_authentication_namespace_is_never_covered` fails if the guard is removed.

*App entry*

There is no existing signal. `apps.views.apps.AppViewSet` exposes a retrieve view keyed on app name, but nothing calls it; the only consumer of the service is `omniport-frontend-formula-one`, which lists apps for the launcher. Entry is therefore inferred from the first request a session makes into each namespace.

It is deduplicated to one line per namespace per session per day, held in the session itself, which bounds that record by people rather than by traffic. Requests with no session key are skipped rather than made to create one, leaving token-authenticated traffic alone; the cost is that OAuth clients produce no entry line, which is correct since they do not open anything.

*Volume*

The per-request line is not deduplicated, so this is a real increase in log volume, and the polling services are the bulk of it. `backupCount` is 32 with midnight rotation. Worth watching `df -h /` and the size of `1-core.log` for a few days after deploy. If the polling services dominate, narrowing is one condition in `discovered_namespace`.

*Infrastructure*

Rebased onto master after the security PRs landed, which brought `tests/` and `.github/workflows/tests.yml` with them. This branch no longer adds either, nor the Python bytecode `.gitignore` rule, all of which master now has. What remains is one step: the middleware reads Django settings, so the workflow installs Django pinned to the `poetry.lock` version before running the suite.

**Testing**
```
python -m unittest discover --start-directory tests --verbose
```
12 tests, all passing: the 9 added here plus master's 3 dependency-advisory tests. Every assertion was observed failing before being believed:

| Mutation | Result |
|---|---|
| authentication guard removed | 1 failure |
| namespace membership ignored | 1 failure |
| predicate always returns `None` | 1 failure |
| entry dedupe removed, always log | 1 failure |
| entry deduped forever, ignoring the date | 1 failure |
| session-key guard removed | 1 failure |
| restored | passes |

To verify on a running instance:
```
docker exec "$APP" tail -f /web_server_logs/gunicorn_logs/1-core.log
```
Expected lines:
```
INFO ... auth_security ❯ ['AUTH_SECURITY'] User <name>(<id>) Opened bhawan_app
INFO ... auth_security ❯ ['AUTH_SECURITY'] User <name>(<id>) GET /api/bhawan_app/gvb/resident/download/?all=true returned status 200
```
Reloading the app should not produce a second `Opened` line the same day. Completing an OAuth authorisation should produce no line carrying `code=` or `state=`.

**Evidence**
Not applicable; no user-facing change.
