### PR TITLE
Reserve the entry line for apps

### DIFF
--- a/omniport/omniport/middleware/auth_security.py
+++ b/omniport/omniport/middleware/auth_security.py
@@ -20,10 +20,13 @@ class AuditLoggingMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
-        self.namespaces = frozenset(
+        self.app_namespaces = frozenset(
             configuration.nomenclature.name
             for _, configuration in settings.DISCOVERY.apps
-            + settings.DISCOVERY.services
+        )
+        self.namespaces = self.app_namespaces | frozenset(
+            configuration.nomenclature.name
+            for _, configuration in settings.DISCOVERY.services
         )
 
     def __call__(self, request):
@@ -57,7 +60,7 @@ class AuditLoggingMiddleware:
                 'info',
                 user
             )
-            if user is not None:
+            if user is not None and app_name in self.app_namespaces:
                 self.log_app_entry(request, app_name, user)
 
         return response
@@ -103,7 +106,9 @@ class AuditLoggingMiddleware:
     def log_app_entry(self, request, app_name, user):
         """
         Record a session opening an app, skipping the request-per-request
-        repetition that would otherwise bury the record it is kept for
+        repetition that would otherwise bury the record it is kept for.
+        Services are excluded: the shell polls them on every page load, so
+        an entry line for them says nothing about what a person opened
         """
 
         session = getattr(request, 'session', None)

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -106,6 +106,96 @@ class AppEntryTestCase(unittest.TestCase):
         self.assertEqual(self.logged, [])
 
 
+def discovery_of(apps, services):
+    """
+    A stand-in for settings.DISCOVERY, whose entries are (module, config)
+    pairs the middleware reads the nomenclature name off
+    """
+
+    def entries(names):
+        return [
+            (name, types.SimpleNamespace(
+                nomenclature=types.SimpleNamespace(name=name)))
+            for name in names
+        ]
+
+    return types.SimpleNamespace(
+        DISCOVERY=types.SimpleNamespace(
+            apps=entries(apps), services=entries(services)
+        )
+    )
+
+
+class NamespaceSetsTestCase(unittest.TestCase):
+    """
+    Tests for the two sets AuditLoggingMiddleware builds at startup
+    """
+
+    def setUp(self):
+        with unittest.mock.patch(
+            'omniport.middleware.auth_security.settings',
+            discovery_of(['bhawan_app'], ['notifications']),
+        ):
+            self.middleware = AuditLoggingMiddleware(lambda request: None)
+
+    def test_apps_alone_earn_entry_lines(self):
+        self.assertEqual(self.middleware.app_namespaces, {'bhawan_app'})
+
+    def test_services_are_still_logged_per_request(self):
+        self.assertEqual(
+            self.middleware.namespaces, {'bhawan_app', 'notifications'}
+        )
+
+
+class EntryLineTestCase(unittest.TestCase):
+    """
+    Tests for which namespaces earn an "Opened" line, exercised through
+    __call__ because that is where the distinction is drawn
+    """
+
+    def setUp(self):
+        self.logged = []
+        self.middleware = AuditLoggingMiddleware.__new__(AuditLoggingMiddleware)
+        self.middleware.app_namespaces = frozenset({'bhawan_app'})
+        self.middleware.namespaces = frozenset({'bhawan_app', 'notifications'})
+        self.middleware.get_response = lambda request: types.SimpleNamespace(
+            status_code=200
+        )
+
+    def call(self, app_name):
+        request = types.SimpleNamespace(
+            method='GET',
+            user=types.SimpleNamespace(is_anonymous=False),
+            resolver_match=types.SimpleNamespace(app_name=app_name),
+            session=StubSession(),
+            get_full_path=lambda: f'/api/{app_name}/thing/',
+        )
+        with unittest.mock.patch(
+            'omniport.middleware.auth_security.auth_security_log',
+            lambda message, level, user: self.logged.append(message),
+        ):
+            self.middleware(request)
+
+    def test_an_app_earns_an_entry_line(self):
+        self.call('bhawan_app')
+        self.assertIn('Opened bhawan_app', self.logged)
+
+    def test_a_service_earns_no_entry_line(self):
+        """
+        The shell polls the services on every page load, so an entry line
+        for one says nothing about what a person opened
+        """
+
+        self.call('notifications')
+        self.assertNotIn('Opened notifications', self.logged)
+
+    def test_a_service_is_still_logged_per_request(self):
+        self.call('notifications')
+        self.assertEqual(
+            self.logged, ['GET /api/notifications/thing/ returned status 200']
+        )
+
+
 class DiscoveredNamespaceTestCase(unittest.TestCase):
     """
     Tests for AuditLoggingMiddleware.discovered_namespace


### PR DESCRIPTION
**Description**
[hotfix] Reserves the `Opened <namespace>` line for apps. Services keep their per-request line.

Observed in production within minutes of #237 deploying.

**Fixes**
No issue filed. Follows #237.

**Technical**
Services earned an entry line too, and the shell polls them on every page load, so the record filled with people "opening" things they never opened:

```
User: Mess Manager Cautley bhawan(9681) Opened apps
User: Mess Manager Cautley bhawan(9681) Opened notifications
User: Mess Manager Cautley bhawan(9681) Opened feed
User: Bhawna(24284) Opened groups
```

It was worse than noise. Opening an app fetches `/api/apps/app/<name>/`, which belongs to the `apps` **service**, so opening the noticeboard produced:

```
User: Shreyash Rautela (32407) GET /api/apps/app/noticeboard/ returned status 200
User: Shreyash Rautela (32407) Opened apps
```

The one line whose job was to name what a person opened named the wrong thing.

`__init__` now builds two sets. `app_namespaces` is the discovered apps and gates the entry line. `namespaces` is those plus the services and gates the per-request line, unchanged. Services were included in #237 deliberately, because `common_biodata` and the biodata services hold personal data and their reads still need a record; that is untouched here.

Worth noting for #237's own record: it claimed `AppViewSet.retrieve` was dead code because nothing appeared to call it. Production traffic shows it is called, on every app open. The retrieve path is built dynamically in the frontend, which is why a grep for the literal URL missed it.

**Testing**
```
python -m unittest discover --start-directory tests --verbose
```
17 tests, all passing. The new assertions were each observed failing before being believed:

| Mutation | Result |
|---|---|
| entry-line gate removed, restoring the old behaviour | 2 failures |
| no entry line emitted at all | 1 failure |
| services folded back into `app_namespaces` | 1 failure |
| restored | passes |

That last mutation initially **survived**, because the first draft of the tests set `app_namespaces` directly and never exercised how `__init__` builds it from `settings.DISCOVERY`. `NamespaceSetsTestCase` was added to close that, and the mutation now fails.

To verify on a running instance:
```
docker exec "$APP" grep "Opened " /web_server_logs/gunicorn_logs/1-core.log | tail -20
```
No `Opened apps`, `Opened feed`, `Opened notifications` or `Opened groups`. `Opened bhawan_app` and its peers remain.

**Evidence**
Not applicable; no user-facing change.
