### PR TITLE
Throttle the OAuth endpoints per client rather than per address

### DIFF
--- a/omniport/core/open_auth/tests.py
+++ b/omniport/core/open_auth/tests.py
@@ -5,11 +5,15 @@ from django.test import SimpleTestCase, override_settings
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
-from open_auth.views.throttling import OAuthClientThrottle
+from open_auth.views.throttling import OAuthClientThrottle, OAuthFailureThrottle
 
 
 class ThreePerHourThrottle(OAuthClientThrottle):
     THROTTLE_RATES = {'open_auth': '3/hour'}
+
+
+class ThreeFailuresThrottle(OAuthFailureThrottle):
+    THROTTLE_RATES = {'open_auth_failures': '3/hour'}
 
 
 @override_settings(CACHES={'default': {
@@ -62,3 +66,28 @@ class OAuthClientThrottleTests(SimpleTestCase):
 
         self.assertFalse(allowed)
         self.assertGreater(throttle.wait(), 0)
+
+    def test_a_client_that_only_succeeds_is_never_failure_throttled(self):
+        for _ in range(10):
+            self.assertTrue(
+                ThreeFailuresThrottle().allow_request(
+                    self.token_request('election'), None
+                )
+            )
+
+    def test_failures_are_counted_until_the_client_is_refused(self):
+        for _ in range(3):
+            request = self.token_request('election')
+            self.assertTrue(ThreeFailuresThrottle().allow_request(request, None))
+            ThreeFailuresThrottle().count(request)
+
+        self.assertFalse(
+            ThreeFailuresThrottle().allow_request(
+                self.token_request('election'), None
+            )
+        )
+        self.assertTrue(
+            ThreeFailuresThrottle().allow_request(
+                self.token_request('noticeboard'), None
+            )
+        )

--- a/omniport/core/open_auth/tests.py
+++ b/omniport/core/open_auth/tests.py
@@ -1,0 +1,64 @@
+import base64
+
+from django.core.cache import cache
+from django.test import SimpleTestCase, override_settings
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from open_auth.views.throttling import OAuthClientThrottle
+
+
+class ThreePerHourThrottle(OAuthClientThrottle):
+    THROTTLE_RATES = {'open_auth': '3/hour'}
+
+
+@override_settings(CACHES={'default': {
+    'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+}})
+class OAuthClientThrottleTests(SimpleTestCase):
+    """
+    Tests that the throttle counts a client application, and not an address
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.factory = APIRequestFactory()
+
+    def token_request(self, client_id=None, ip='10.0.0.1', **extra):
+        body = {'grant_type': 'authorization_code'}
+        if client_id:
+            body['client_id'] = client_id
+        return Request(self.factory.post(
+            '/open_auth/token/', body, REMOTE_ADDR=ip, **extra
+        ))
+
+    def allow(self, client_id=None, ip='10.0.0.1', **extra):
+        request = self.token_request(client_id, ip, **extra)
+        return ThreePerHourThrottle().allow_request(request, None)
+
+    def test_clients_sharing_an_address_are_counted_apart(self):
+        for _ in range(3):
+            self.assertTrue(self.allow('election'))
+        self.assertFalse(self.allow('election'))
+        self.assertTrue(self.allow('noticeboard'))
+
+    def test_one_client_is_counted_across_addresses(self):
+        for ip in ('10.0.0.1', '10.0.0.2', '10.0.0.3'):
+            self.assertTrue(self.allow('election', ip))
+        self.assertFalse(self.allow('election', '10.0.0.4'))
+
+    def test_a_client_naming_itself_in_the_header_is_counted(self):
+        credentials = base64.b64encode(b'election:secret').decode()
+        for _ in range(3):
+            self.assertTrue(
+                self.allow(HTTP_AUTHORIZATION=f'Basic {credentials}')
+            )
+        self.assertFalse(self.allow('election'))
+
+    def test_a_throttled_client_is_told_when_to_retry(self):
+        throttle = ThreePerHourThrottle()
+        for _ in range(4):
+            allowed = throttle.allow_request(self.token_request('election'), None)
+
+        self.assertFalse(allowed)
+        self.assertGreater(throttle.wait(), 0)

--- a/omniport/core/open_auth/tests.py
+++ b/omniport/core/open_auth/tests.py
@@ -16,6 +16,12 @@ class ThreeFailuresThrottle(OAuthFailureThrottle):
     THROTTLE_RATES = {'open_auth_failures': '3/hour'}
 
 
+class Rejection:
+    def __init__(self, content, status_code=400):
+        self.content = content
+        self.status_code = status_code
+
+
 @override_settings(CACHES={'default': {
     'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
 }})
@@ -91,3 +97,27 @@ class OAuthClientThrottleTests(SimpleTestCase):
                 self.token_request('noticeboard'), None
             )
         )
+
+    def test_a_stranger_cannot_spend_the_allowance_of_a_client(self):
+        for _ in range(3):
+            ThreeFailuresThrottle().count(
+                self.token_request('election', '203.0.113.9')
+            )
+
+        self.assertFalse(
+            ThreeFailuresThrottle().allow_request(
+                self.token_request('election', '203.0.113.9'), None
+            )
+        )
+        self.assertTrue(
+            ThreeFailuresThrottle().allow_request(
+                self.token_request('election', '10.0.0.1'), None
+            )
+        )
+
+    def test_only_a_client_that_cannot_prove_itself_is_counted(self):
+        counted = ThreeFailuresThrottle.is_credential_failure
+        self.assertTrue(counted(Rejection(b'{"error": "invalid_client"}')))
+        self.assertTrue(counted(Rejection(b'', status_code=401)))
+        self.assertFalse(counted(Rejection(b'{"error": "invalid_grant"}')))
+        self.assertFalse(counted(Rejection(b'', status_code=302)))

--- a/omniport/core/open_auth/views/throttling.py
+++ b/omniport/core/open_auth/views/throttling.py
@@ -1,5 +1,49 @@
+import base64
+
+from rest_framework.authentication import get_authorization_header
 from rest_framework.permissions import AllowAny
+from rest_framework.throttling import SimpleRateThrottle
 from rest_framework.views import APIView
+
+
+class OAuthClientThrottle(SimpleRateThrottle):
+    """
+    Throttle that counts requests against the client that sends them, and not
+    the address, which every user of an application shares
+    """
+
+    scope = 'open_auth'
+
+    def get_client_id(self, request):
+        header = get_authorization_header(request).split()
+        if len(header) == 2 and header[0].lower() == b'basic':
+            try:
+                return base64.b64decode(header[1]).split(b':')[0].decode()
+            except (ValueError, UnicodeDecodeError):
+                pass
+
+        # Django caches the form it parses, so the view below still reads it
+        return request._request.POST.get('client_id') or self.get_ident(request)
+
+    def allow_request(self, request, view):
+        if self.rate is None:
+            return True
+
+        window = int(self.timer()) // self.duration
+        self.key = f'throttle_{self.scope}_{self.get_client_id(request)}_{window}'
+
+        # A counter, since the inherited history is read-modify-write and
+        # loses increments when workers run concurrently
+        try:
+            count = self.cache.incr(self.key)
+        except ValueError:
+            self.cache.add(self.key, 1, self.duration)
+            count = 1
+
+        return count <= self.num_requests
+
+    def wait(self):
+        return self.duration - (self.timer() % self.duration)
 
 
 class ThrottledOAuthLibView(APIView):
@@ -11,7 +55,7 @@ class ThrottledOAuthLibView(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
     oauthlib_view = None
-    throttle_scope = 'open_auth'
+    throttle_classes = [OAuthClientThrottle]
 
     def post(self, request, *args, **kwargs):
         """

--- a/omniport/core/open_auth/views/throttling.py
+++ b/omniport/core/open_auth/views/throttling.py
@@ -1,4 +1,5 @@
 import base64
+import json
 
 from rest_framework.authentication import get_authorization_header
 from rest_framework.permissions import AllowAny
@@ -25,9 +26,12 @@ class OAuthClientThrottle(SimpleRateThrottle):
         # Django caches the form it parses, so the view below still reads it
         return request._request.POST.get('client_id') or self.get_ident(request)
 
+    def get_identity(self, request):
+        return self.get_client_id(request)
+
     def get_key(self, request):
         window = int(self.timer()) // self.duration
-        return f'throttle_{self.scope}_{self.get_client_id(request)}_{window}'
+        return f'throttle_{self.scope}_{self.get_identity(request)}_{window}'
 
     def count(self, request):
         # A counter, since the inherited history is read-modify-write and
@@ -56,6 +60,22 @@ class OAuthFailureThrottle(OAuthClientThrottle):
     """
 
     scope = 'open_auth_failures'
+
+    @staticmethod
+    def is_credential_failure(response):
+        # The codes RFC 6749 defines for a client that cannot prove who it is.
+        # Every other rejection is something an ordinary user flow produces
+        try:
+            error = json.loads(response.content).get('error')
+        except (ValueError, TypeError, AttributeError):
+            return response.status_code == 401
+
+        return error in ('invalid_client', 'unauthorized_client')
+
+    def get_identity(self, request):
+        # Also the address, so that a stranger naming a client cannot spend
+        # the allowance that client's own server depends on
+        return f'{self.get_client_id(request)}_{self.get_ident(request)}'
 
     def allow_request(self, request, view):
         if self.rate is None:
@@ -89,7 +109,7 @@ class ThrottledOAuthLibView(APIView):
         # The toolkit view reads the form body itself, and nothing above has
         # consumed the stream, so hand it the untouched Django request
         response = self.oauthlib_view(request._request, *args, **kwargs)
-        if response.status_code >= 400:
+        if OAuthFailureThrottle.is_credential_failure(response):
             OAuthFailureThrottle().count(request)
 
         return response

--- a/omniport/core/open_auth/views/throttling.py
+++ b/omniport/core/open_auth/views/throttling.py
@@ -25,25 +25,45 @@ class OAuthClientThrottle(SimpleRateThrottle):
         # Django caches the form it parses, so the view below still reads it
         return request._request.POST.get('client_id') or self.get_ident(request)
 
+    def get_key(self, request):
+        window = int(self.timer()) // self.duration
+        return f'throttle_{self.scope}_{self.get_client_id(request)}_{window}'
+
+    def count(self, request):
+        # A counter, since the inherited history is read-modify-write and
+        # loses increments when workers run concurrently
+        key = self.get_key(request)
+        try:
+            return self.cache.incr(key)
+        except ValueError:
+            self.cache.add(key, 1, self.duration)
+            return 1
+
     def allow_request(self, request, view):
         if self.rate is None:
             return True
 
-        window = int(self.timer()) // self.duration
-        self.key = f'throttle_{self.scope}_{self.get_client_id(request)}_{window}'
-
-        # A counter, since the inherited history is read-modify-write and
-        # loses increments when workers run concurrently
-        try:
-            count = self.cache.incr(self.key)
-        except ValueError:
-            self.cache.add(self.key, 1, self.duration)
-            count = 1
-
-        return count <= self.num_requests
+        return self.count(request) <= self.num_requests
 
     def wait(self):
         return self.duration - (self.timer() % self.duration)
+
+
+class OAuthFailureThrottle(OAuthClientThrottle):
+    """
+    Throttle that counts only the requests the wrapped view rejected, so that
+    the rate allowed does not have to accommodate how popular a client is
+    """
+
+    scope = 'open_auth_failures'
+
+    def allow_request(self, request, view):
+        if self.rate is None:
+            return True
+
+        # Read only, since the view counts a request once it knows the
+        # outcome, which is after every throttle has run
+        return (self.cache.get(self.get_key(request)) or 0) < self.num_requests
 
 
 class ThrottledOAuthLibView(APIView):
@@ -55,7 +75,7 @@ class ThrottledOAuthLibView(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
     oauthlib_view = None
-    throttle_classes = [OAuthClientThrottle]
+    throttle_classes = [OAuthClientThrottle, OAuthFailureThrottle]
 
     def post(self, request, *args, **kwargs):
         """
@@ -68,4 +88,8 @@ class ThrottledOAuthLibView(APIView):
 
         # The toolkit view reads the form body itself, and nothing above has
         # consumed the stream, so hand it the untouched Django request
-        return self.oauthlib_view(request._request, *args, **kwargs)
+        response = self.oauthlib_view(request._request, *args, **kwargs)
+        if response.status_code >= 400:
+            OAuthFailureThrottle().count(request)
+
+        return response

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -41,7 +41,7 @@ REST_FRAMEWORK = {
         'user': '5000/hour',
         'login': '300/hour',
         'reset_password': '5/hour',
-        'open_auth': '1000/hour',
+        'open_auth': '50000/hour',
         'media_authorisation': '20000/hour',
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -42,6 +42,7 @@ REST_FRAMEWORK = {
         'login': '300/hour',
         'reset_password': '5/hour',
         'open_auth': '50000/hour',
+        'open_auth_failures': '1000/hour',
         'media_authorisation': '20000/hour',
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',

--- a/omniport/omniport/settings/third_party/drf.py
+++ b/omniport/omniport/settings/third_party/drf.py
@@ -42,7 +42,7 @@ REST_FRAMEWORK = {
         'login': '300/hour',
         'reset_password': '5/hour',
         'open_auth': '50000/hour',
-        'open_auth_failures': '1000/hour',
+        'open_auth_failures': '100/hour',
         'media_authorisation': '20000/hour',
         'verify_secret_answer': '5/hour',
         'verify_recovery_token': '10/hour',


### PR DESCRIPTION
## Summary

`ThrottledOAuthLibView` declares no authentication, because OAuth clients identify themselves by their credentials rather than by a session. The throttles applied by default therefore have no user to key on and fall back to the address.

The token endpoint is reached by the client application's server, not by the browser, so every user of an application is counted into one bucket, and an application reaches its limit in proportion to how many people use it. `/authorise/` is session authenticated and keyed per user, so it stays unaffected, which makes the failure look like the application's rather than the limit's.

`OAuthClientThrottle` counts against the client named in the HTTP Basic credentials or the form body, falling back to the address when a request names none. `allow_request` is overridden because the inherited request history is a list read from and written back to the cache, which loses increments under concurrency and so does not hold the limit at its stated number.

A rate that has to accommodate a client's busiest hour is far too loose to stop a client working through credentials, so the two are separated:

- `open_auth`, `50000/hour`, a ceiling on volume per client, above the roughly 23,000 requests an hour measured from a single application at its peak
- `open_auth_failures`, `100/hour`, counted only when a client cannot prove who it is

The second is counted against the address as well as the client. A client names itself in the open, so counting against the client alone would let a stranger spend an application's allowance and leave its users unable to sign in. It also counts only the error codes RFC 6749 defines for a client that cannot prove itself, since an expired authorisation code is rejected the same way and ordinary users produce those by retrying.

## Test plan

- [ ] `python manage.py test open_auth` passes
- [ ] Reduce `get_client_id` to `return self.get_ident(request)` and confirm `test_clients_sharing_an_address_are_counted_apart` fails
- [ ] On staging at `5/hour`, eight token requests as `TEST_A` return `429` from the sixth, and three as `TEST_B` from the same host are served
- [ ] On staging with `open_auth_failures` at `3/hour`, four requests carrying a bad client secret return `429` on the fourth, while the same client from another address is served
- [ ] Four requests carrying a spent authorisation code are all served, since an expired grant is not a credential failure
- [ ] `ThrottledOAuthLibView().get_throttles()` reports both throttles on the deployed instance
- [ ] After live traffic, `throttle_open_auth_<client_id>_<window>` holds a count and the same key built from the address holds none